### PR TITLE
Ensure we iterate over a stable collection when creating cards

### DIFF
--- a/src/ddqa/screens/create.py
+++ b/src/ddqa/screens/create.py
@@ -151,7 +151,7 @@ class CandidateListing(DataTable):
         self.app.print(f'Candidates ready for creation: {total}')
         self.sidebar.status.update('Creating...')
         async with ResponsiveNetworkClient(self.sidebar.status) as client:
-            for index, candidate in self.candidates.items():
+            for index, candidate in list(self.candidates.items()):
                 self.app.print(f'Creating issue for {candidate.data.long_display()}')
 
                 assignments: dict[str, str] = {}


### PR DESCRIPTION
To avoid an exception if the size of the collection changes within the loop, which can happen due to the candidates being fetched async.

I came across this when hitting `Create` pretty early (after assigning just one card), I assume that simultaneously with candidate collection.