### PR TITLE
Fix github api query

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- Fix Github API search query
+
 ## 0.4.0 - 2023-06-21
 
 ***Added:***

--- a/src/ddqa/utils/github.py
+++ b/src/ddqa/utils/github.py
@@ -123,7 +123,7 @@ class GitHubRepository:
             client,
             self.ISSUE_SEARCH_API,
             # https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests
-            params={'q': f'sha:{commit.hash}+repo:{self.repo_id}'},
+            params={'q': f'sha:{commit.hash} repo:{self.repo_id}'},
         )
         pr_data = response.json()
 


### PR DESCRIPTION
Was getting an issue with the search query returning more than one result when using the following:
https://api.github.com/search/issues?q=sha%3A441957c74d74d70422f1cde1275acfc3a9970637%2Brepo%3ADataDog%2Fintegrations-core

The fix would change it to:
https://api.github.com/search/issues?q=sha%3A441957c74d74d70422f1cde1275acfc3a9970637%20repo%3ADataDog%2Fintegrations-core

Which returns the correct entry