### PR TITLE
Fix warnings

### DIFF
--- a/src/ddqa/widgets/static.py
+++ b/src/ddqa/widgets/static.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2023-present Datadog, Inc. <dev@datadoghq.com>
 #
 # SPDX-License-Identifier: MIT
-
 from textual.widgets import Static
 
 

--- a/src/ddqa/widgets/static.py
+++ b/src/ddqa/widgets/static.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present Datadog, Inc. <dev@datadoghq.com>
 #
 # SPDX-License-Identifier: MIT
+
 from textual.widgets import Static
 
 
@@ -19,7 +20,7 @@ class Placeholder(Static):
 
     def on_mount(self):
         import shutil
-        from importlib.resources import read_binary
+        from importlib.resources import files
         from io import BytesIO
 
         from PIL import Image
@@ -28,7 +29,7 @@ class Placeholder(Static):
         ascii_chars = '@S#%?*+;:, '
         buckets = 256 // (len(ascii_chars) - 1)
 
-        with BytesIO(read_binary('ddqa.data', 'logo.png')) as buffer, Image.open(buffer) as raw_image:
+        with BytesIO(files('ddqa.data').joinpath('logo.png').read_bytes()) as buffer, Image.open(buffer) as raw_image:
             old_width, old_height = raw_image.size
             new_width = int(shutil.get_terminal_size()[0] // self.__width_factor)
             new_height = int(old_height // (old_width / (new_width * self.__height_scale)))

--- a/tests/utils/test_jira.py
+++ b/tests/utils/test_jira.py
@@ -10,7 +10,7 @@ import pytest
 from httpx import Request, Response
 from textual.widgets import Static
 
-from ddqa.models.github import TestCandidate
+from ddqa.models.github import TestCandidate as Candidate
 from ddqa.utils.network import ResponsiveNetworkClient
 
 
@@ -156,7 +156,7 @@ async def test_create_issues(app, git_repository, helpers, mocker):
 
     created_issues = await app.jira.create_issues(
         ResponsiveNetworkClient(Static()),
-        TestCandidate(
+        Candidate(
             **{
                 'id': '123',
                 'title': 'title123',
@@ -675,7 +675,7 @@ async def test_rate_limit_handling(app, git_repository, mocker):
     start = time.time()
     created_issues = await app.jira.create_issues(
         ResponsiveNetworkClient(Static()),
-        TestCandidate(
+        Candidate(
             **{
                 'id': '123',
                 'title': 'title123',


### PR DESCRIPTION
We have two warnings when we run the tests: 

```
========================================================================================================================================================================= warnings summary ==========================================================================================================================================================================
src/ddqa/models/github.py:19
  /Users/florent.clarret/go/src/github.com/DataDog/ddqa/src/ddqa/models/github.py:19: PytestCollectionWarning: cannot collect test class 'TestCandidate' because it has a __init__ constructor (from: tests/utils/test_jira.py)
    class TestCandidate(BaseModel):

tests/screens/test_configure.py: 21 warnings
tests/screens/test_sync.py: 5 warnings
tests/screens/test_create.py: 8 warnings
  /Users/florent.clarret/go/src/github.com/DataDog/ddqa/src/ddqa/widgets/static.py:31: DeprecationWarning: read_binary is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
    with BytesIO(read_binary('ddqa.data', 'logo.png')) as buffer, Image.open(buffer) as raw_image:

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

Relates to https://datadoghq.atlassian.net/browse/AITS-291