### PR TITLE
Do not sign commits when running the tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,6 +159,7 @@ def git_repository(isolation, temp_dir):
 
     try:
         subprocess.run(['git', 'init'], **options)
+        subprocess.run(['git', 'config', '--local', 'commit.gpgsign', 'false'], **options)
         subprocess.run(['git', 'config', '--local', 'user.name', 'foo'], **options)
         subprocess.run(['git', 'config', '--local', 'user.email', 'foo@bar.baz'], **options)
         subprocess.run(['git', 'commit', '-m', 'init', '--allow-empty'], **options)


### PR DESCRIPTION
I use my Yubikey to sign commits, so each time the fixture run I need to touch it. This PR explicitly configure the created repository to avoid signing commits.

I know this solution is not ideal, we should find a way to avoid leaking our own config to the test environment but I did not find a way to do that easily. The config option always load global files.

Note: we have the exact same issue on `ddev`