### PR TITLE
Disable the radio button in the status screen if the user is not assigned to the card

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ***Fixed:***
 
 - Fix Github API search query
+- Disable the radio button in the status screen if the user is not assigned to the card
 
 ## 0.4.0 - 2023-06-21
 

--- a/src/ddqa/screens/status.py
+++ b/src/ddqa/screens/status.py
@@ -473,6 +473,11 @@ class StatusScreen(Screen):
         current_status = self.get_qa_status(issue)
         self.status_changer.radio_buttons[current_status].value = True
 
+        disabled_radio_button = issue.assignee is None or issue.assignee.id != self.current_user_id
+
+        for radio_button in self.status_changer.radio_buttons.values():
+            radio_button.disabled = disabled_radio_button
+
     async def on_radio_set_changed(self, event: RadioSet.Changed) -> None:
         current_issue = self.cached_issues[str(self.issues.label.render()).strip()]
         current_status = self.get_qa_status(current_issue)


### PR DESCRIPTION
The user does not have the right to change the status of a card if they're not assigned to it

| Before | After |
|--------|-------|
| ![before](https://github.com/DataDog/ddqa/assets/1266346/cbe95ba9-65d7-44ce-ae54-e8b892e97a2d)  |   ![after](https://github.com/DataDog/ddqa/assets/1266346/b9df9fc0-606b-4b34-a1d2-fb3bf86770ed) |

In case you missed it, my user is "Florent Clarret".

I don't really know how to implement a unit test for this though.

https://datadoghq.atlassian.net/browse/AITS-208