### PR TITLE
Consider unknown statuses as Done

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix GitHub API search query
 - Disable the radio button in the status screen if the user is not assigned to the card
 - Alphabetically sort the teams and members in the status screen
+- Consider unknown Jira statuses as Done and add an extra column in the Done box to specify the current status of this card
 
 ## 0.4.0 - 2023-06-21
 


### PR DESCRIPTION
# Problem

- Currently we have a 1:1 mapping between our QA statuses and the Jira statuses
- We only handle 3 QA statuses: To do, In progress, and Done
- Most of the time, this 1:1 mapping works well enough but sometimes teams have several final statuses (i.e. "Won't do")

In this case, the cards appear in the "In progress" box, which is wrong. This also make the progression pourcentage wrong because these cards are considered as "To do", so we never reach 100%

Note: Currently teams never have several initial/in progress statuses. 

# What does this PR do?

- Consider any unknown Jira statuses as Done. This "Done" should be read as "there's nothing else to do with this card, we already dealt with it"
- Add an extra column to the "Done" table called "Info" and print the real status if different from the known "Done" status
- Refactor the Status and StatusScreen classes to delegate some responsibilities to the Status (i.e. how to add issue, how to sort them) instead of having the logic in the Status Screen
- Fix the progression pourcentage

# Show time

| Before | After |
|--------|-------|
|  ![Screenshot 2023-11-13 at 11 15 50](https://github.com/DataDog/ddqa/assets/1266346/fe066bb1-6bab-4944-914f-a20ea700d5b5)   |  ![Screenshot 2023-11-13 at 11 11 59](https://github.com/DataDog/ddqa/assets/1266346/e786f38e-8390-4ba7-955d-c111263fde70)  |

# Additional note

I know this is a very opinionated way to fix this. We could also allow having multiple jira statuses for a given QA status, but it would need to modify a lot of stuff in the logic. Also I don't think we can have several initial and in progress statuses, so this would be useful only for final statuses. Furthermore, we would still have the same issue if a team creates a new final status without updating the config. 

Relates to:

- https://datadoghq.atlassian.net/browse/AITS-209
- https://datadoghq.atlassian.net/browse/AITS-300