### PR TITLE
Fix some linter warnings

### DIFF
--- a/src/ddqa/app/core.py
+++ b/src/ddqa/app/core.py
@@ -81,8 +81,7 @@ class Application(App):
         for team, config in self.repo.teams.items():
             statuses = {}
             if isinstance(config.jira_statuses, dict):
-                missing_statuses = set(self.repo.qa_statuses).difference(config.jira_statuses)
-                if missing_statuses:
+                if missing_statuses := set(self.repo.qa_statuses).difference(config.jira_statuses):
                     ordered_statuses = [status for status in self.repo.qa_statuses if status in missing_statuses]
                     message = f'repos -> {team} -> jira_statuses\n  missing statuses: {", ".join(ordered_statuses)}'
                     raise ValueError(message)

--- a/src/ddqa/config/core.py
+++ b/src/ddqa/config/core.py
@@ -85,8 +85,6 @@ class TypeResilientDict(dict):
     def get(self, key: Any, default: Any = None) -> Any:
         try:
             value = super().get(key, default)
-            if isinstance(value, dict):
-                return TypeResilientDict(value)
-            return value
+            return TypeResilientDict(value) if isinstance(value, dict) else value
         except TypeError:
             return default

--- a/src/ddqa/screens/configure.py
+++ b/src/ddqa/screens/configure.py
@@ -204,8 +204,7 @@ class ConfigurationInput(Widget):
 
     def on_mount(self) -> None:
         text_log = self.query_one(RichLog)
-        errors = self.app.config_errors()
-        if errors:
+        if errors := self.app.config_errors():
             text_log.write(error_tree(errors), shrink=False)
 
 

--- a/src/ddqa/screens/status.py
+++ b/src/ddqa/screens/status.py
@@ -532,14 +532,6 @@ class StatusScreen(Screen):
         self.status_changer.button.disabled = True
         self.__update_completion_status()
 
-    def __get_status_label(self, labels: list[str]) -> str:
-        for label in labels:
-            if label in self.statuses:
-                return label
-
-        message = f'Unknown status: {labels}'
-        raise ValueError(message)
-
     def __refocus(self) -> None:
         # Focus on the first available row of the first table with entries
         focused = False
@@ -554,10 +546,7 @@ class StatusScreen(Screen):
                 status.table.show_cursor = False
 
     def __update_completion_status(self) -> None:
-        counts = []
-        for status in self.statuses.values():
-            counts.append(len(status.table.rows))
-
+        counts = [len(status.table.rows) for status in self.statuses.values()]
         total = sum(counts)
         done = counts[-1]
 

--- a/src/ddqa/utils/network.py
+++ b/src/ddqa/utils/network.py
@@ -41,7 +41,8 @@ class ResponsiveNetworkClient(httpx.AsyncClient):
 
         self.status.update(original_status)
 
-    def check_status(self, response: httpx.Response, **kwargs) -> None:
+    @staticmethod
+    def check_status(response: httpx.Response, **kwargs) -> None:
         try:
             response.raise_for_status()
         except httpx.HTTPStatusError as e:


### PR DESCRIPTION
Very nit PR to fix some warnings my linter noticed: 

- Use list comprehension when needed
- Remove unused methods
- Use walrus operator
