### PR TITLE
Filter out the PRs with specific tags

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add a set of commands to interact with the cache
 - Show the author of a PR on the create screen
 - Make the team labels clickable in the create screen
+- Do not show PRs that have a ignored label in the create screen
 
 ## 0.4.0 - 2023-06-21
 

--- a/tests/screens/test_create.py
+++ b/tests/screens/test_create.py
@@ -558,7 +558,7 @@ class TestAssignment:
                 'number': '1',
                 'title': 'title1',
                 'user': {'login': 'username1'},
-                'labels': [{'name': 'bar-label', 'color': '632ca6'}, {'name': 'baz-label', 'color': '632ca6'}],
+                'labels': [{'name': 'bar-label', 'color': '632ca6'}, {'name': 'bar-label', 'color': '632ca6'}],
                 'body': 'foo1\r\nbar1',
             },
         )
@@ -569,21 +569,19 @@ class TestAssignment:
             sidebar = app.query_one(CandidateSidebar)
             table = sidebar.listing
             num_candidates = len(table.rows)
-            assert num_candidates == 3
-            assert table.get_row_at(0) == ['', 'title2']
-            assert table.get_row_at(1) == ['', 'subject3']
-            assert table.get_row_at(2) == ['', 'title1']
+            assert num_candidates == 2
+            assert table.get_row_at(0) == ['', 'subject3']
+            assert table.get_row_at(1) == ['✓', 'title1']
             assert [c.assigned for c in table.candidates.values()] == [
                 False,
-                False,
-                False,
+                True,
             ]
 
             assert table.cursor_coordinate == Coordinate(0, 0)
 
-            assert str(sidebar.label.render()) == f' 0 / {num_candidates} '
-            assert str(sidebar.status.render()) == 'No candidates assigned'
-            assert sidebar.button.disabled
+            assert str(sidebar.label.render()) == ' 1 / 2 '
+            assert str(sidebar.status.render()) == 'Ready for creation'
+            assert not sidebar.button.disabled
 
             rendering = app.query_one(CandidateRendering)
             assignments = list(rendering.candidate_assignments.query(LabeledSwitch).results())
@@ -606,7 +604,6 @@ class TestCreation:
             },
         )
         repo_config = dict(app.repo.dict())
-        repo_config['ignored_labels'] = ['baz-label']
         repo_config['teams'] = {
             'Foo Baz': {
                 'jira_project': 'FOO',
@@ -762,7 +759,7 @@ class TestCreation:
             await pilot.pause(helpers.ASYNC_WAIT)
 
             assert str(sidebar.status.render()) == 'Finished'
-            assert str(sidebar.label.render()) == f' {num_candidates} / {num_candidates} '
+            assert str(sidebar.label.render()) == ' 3 / 3 '
             assert str(sidebar.button.label) == 'Exit'
 
             # We use the following equality assertions as a way to match the progression of member assignment counts and


### PR DESCRIPTION
# Problem

- We currently have an option in the `config.toml` file called `ignored_labels`. This option initialises the team selection buttons to False if the PR has these labels
- In our repository, we only QA PRs that do not have some labels. There can be a lot of them. See the video in the show time section. In this video for this given release in integrations-core, we have about 500 PRs and about 350 of them have a `no-changelog` or `skip-qa` label
- Users would like to hide these PRs to be able to focus on the relevant PRs

# What does this PR do?

- Refactor a bit the way we fetch the PRs. Until now, the logic was mainly in the `create` screen. I moved the logic to the github module and created a new method called `get_candidates` that iterates over the commits and yield the relevant PRs so the screen does not need to deal with that. This also allows us to add more unit tests for this part of the code
- Also display the number of PRs that are ignored when fetching the PRs from github
- Filter out the PRs with the labels specified in the `ignored_labels` config option
- Always update the status bar to let the user know a PR has been ignored
- Add & modify tests accordingly

# Show time

| Before | After |
|--------|-------|
|  ![before](https://github.com/DataDog/ddqa/assets/1266346/91ef6c7a-1811-4624-9dab-30d1ca269c9b)  |   ![after](https://github.com/DataDog/ddqa/assets/1266346/14f6eb52-fb59-427b-afb3-f6b8c5d824a6) |


# Additional note

Relates to:

- https://datadoghq.atlassian.net/browse/AITS-212