### PR TITLE
Strip the PR title in the `create` screen

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Disable the radio button in the status screen if the user is not assigned to the card
 - Alphabetically sort the teams and members in the status screen
 - Consider unknown Jira statuses as Done and add an extra column in the Done box to specify the current status of this card
+- Strip the PR title in the `create` screen
 
 ## 0.4.0 - 2023-06-21
 

--- a/src/ddqa/screens/create.py
+++ b/src/ddqa/screens/create.py
@@ -115,7 +115,7 @@ class CandidateListing(DataTable):
 
                 shown_index = str(index + 1)
                 self.sidebar.label.update(f' {shown_index} / {total - ignored} ')
-                self.add_row(candidate.status_indicator, escape(model.title), key=str(index))
+                self.add_row(candidate.status_indicator, escape(model.title.strip()), key=str(index))
                 num_candidates += 1
 
         if not num_candidates:


### PR DESCRIPTION
Sometimes we have some extra spaces in the beginning of the title of the PR. Let's strip the title to drop them

| Before | After |
|--------|-------|
| ![Screenshot 2023-11-14 at 11 57 31](https://github.com/DataDog/ddqa/assets/1266346/7df8f2bd-a3a9-4322-a9fe-ada46158b26a) |  ![Screenshot 2023-11-14 at 11 58 11](https://github.com/DataDog/ddqa/assets/1266346/4828bd65-5740-4c6c-8cf9-bc8917ab48ae)  |


https://datadoghq.atlassian.net/browse/AITS-302
