### PR TITLE
Fix the help message for the `--cache-dir` option

### DIFF
--- a/src/ddqa/cli/__init__.py
+++ b/src/ddqa/cli/__init__.py
@@ -22,7 +22,7 @@ from ddqa.config.constants import AppEnvVars, ConfigEnvVars
 @click.option(
     '--cache-dir',
     envvar=ConfigEnvVars.CACHE,
-    help='The path to a custom directory used to cache data [env var: `DDQA_CACHE_DIR`]',
+    help='The path to a custom directory used to cache data [env var: `DDQA_CACHE`]',
 )
 @click.option(
     '--config',


### PR DESCRIPTION
The help message is wrong, the env variable is [DDEV_CACHE](https://github.com/DataDog/ddqa/blob/0785953274439fe00d74b25749744e451c1a4504/src/ddqa/config/constants.py#L11)

https://datadoghq.atlassian.net/browse/AITS-303