### PR TITLE
Only retrieve merged PR when fetching them from GitHub

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Alphabetically sort the teams and members in the status screen
 - Consider unknown Jira statuses as Done and add an extra column in the Done box to specify the current status of this card
 - Strip the PR title in the `create` screen
+- Only retrieve merged PRs when fetching them from GitHub
 
 ## 0.4.0 - 2023-06-21
 

--- a/src/ddqa/utils/github.py
+++ b/src/ddqa/utils/github.py
@@ -123,7 +123,7 @@ class GitHubRepository:
             client,
             self.ISSUE_SEARCH_API,
             # https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests
-            params={'q': f'sha:{commit.hash} repo:{self.repo_id}'},
+            params={'q': f'sha:{commit.hash} repo:{self.repo_id} is:merged'},
         )
         pr_data = response.json()
 

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -92,7 +92,9 @@ class TestCandidates:
         )
         assert response_mock.call_args_list == [
             mocker.call(
-                'https://api.github.com/search/issues', params={'q': 'sha:hash9000 repo:org/repo'}, auth=('foo', 'bar')
+                'https://api.github.com/search/issues',
+                params={'q': 'sha:hash9000 repo:org/repo is:merged'},
+                auth=('foo', 'bar'),
             ),
             mocker.call('https://api.github.com/repos/org/repo/pulls/123/reviews', auth=('foo', 'bar')),
         ]
@@ -131,7 +133,9 @@ class TestCandidates:
         )
         assert response_mock.call_args_list == [
             mocker.call(
-                'https://api.github.com/search/issues', params={'q': 'sha:hash9000 repo:org/repo'}, auth=('foo', 'bar')
+                'https://api.github.com/search/issues',
+                params={'q': 'sha:hash9000 repo:org/repo is:merged'},
+                auth=('foo', 'bar'),
             ),
         ]
 
@@ -168,7 +172,9 @@ class TestCandidates:
         )
         assert response_mock.call_args_list == [
             mocker.call(
-                'https://api.github.com/search/issues', params={'q': 'sha:hash1 repo:org/repo'}, auth=('foo', 'bar')
+                'https://api.github.com/search/issues',
+                params={'q': 'sha:hash1 repo:org/repo is:merged'},
+                auth=('foo', 'bar'),
             ),
         ]
         assert candidate.dict() == {
@@ -232,7 +238,9 @@ class TestCandidates:
         )
         assert response_mock.call_args_list == [
             mocker.call(
-                'https://api.github.com/search/issues', params={'q': 'sha:hash2 repo:org/repo'}, auth=('foo', 'bar')
+                'https://api.github.com/search/issues',
+                params={'q': 'sha:hash2 repo:org/repo is:merged'},
+                auth=('foo', 'bar'),
             ),
             mocker.call('https://api.github.com/repos/org/repo/pulls/123/reviews', auth=('foo', 'bar')),
         ]
@@ -264,7 +272,9 @@ class TestCandidates:
         )
         assert response_mock.call_args_list == [
             mocker.call(
-                'https://api.github.com/search/issues', params={'q': 'sha:hash3 repo:org/repo'}, auth=('foo', 'bar')
+                'https://api.github.com/search/issues',
+                params={'q': 'sha:hash3 repo:org/repo is:merged'},
+                auth=('foo', 'bar'),
             ),
         ]
         assert candidate.dict() == {
@@ -572,7 +582,9 @@ async def test_rate_limit_handling(app, git_repository, mocker):
 
     assert response_mock.call_args_list == [
         mocker.call(
-            'https://api.github.com/search/issues', params={'q': 'sha:hash9000 repo:org/repo'}, auth=('foo', 'bar')
+            'https://api.github.com/search/issues',
+            params={'q': 'sha:hash9000 repo:org/repo is:merged'},
+            auth=('foo', 'bar'),
         ),
         mocker.call('https://api.github.com/repos/org/repo/pulls/123/reviews', auth=('foo', 'bar')),
         mocker.call('https://api.github.com/repos/org/repo/pulls/123/reviews', auth=('foo', 'bar')),


### PR DESCRIPTION
# Problem

1. We get [this commit](https://github.com/DataDog/integrations-core/commit/1c7edd04a8c639887b78fb4a49da06ca74ff78df)
2. We call the API with [this API call](https://github.com/DataDog/ddqa/pull/59/files#diff-bc8920013e80017b1a900a2d666449f2f11dbf27f02d750f5b1772a55c2b15beL126) without specifying the PR should be merged
3. We end up with [this PR](https://github.com/DataDog/integrations-core/pull/15993) because they messed up with the rebase and the PR has the commit

Two merged PRs can't have the same commit in their history without having conflicts.

# What does this PR do

Fix the bug, politely asking for merged PR


https://datadoghq.atlassian.net/browse/AITS-306