### PR TITLE
Show the author of a PR on the create screen

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Consider unknown Jira statuses as Done and add an extra column in the Done box to specify the current status of this card
 - Strip the PR title in the `create` screen
 - Only retrieve merged PRs when fetching them from GitHub
+- Show the author of a PR on the create screen
 
 ## 0.4.0 - 2023-06-21
 

--- a/src/ddqa/screens/create.py
+++ b/src/ddqa/screens/create.py
@@ -378,7 +378,12 @@ class CandidateRendering(LabeledBox):
 
     async def render_candidate(self, candidate: Candidate):
         data = candidate.data
-        self.label.update(f' [link={data.url}]{data.short_display()}[/link] ')
+        label = f' [link={data.url}]{data.short_display()}[/link] '
+
+        if data.user:
+            label += f'by [link=https://github.com/{data.user}]{data.user}[/link] '
+
+        self.label.update(label)
         self.title.update(RichMarkdown(data.title))
         self.labels.update(' '.join(f'[black on #{label.color}]{label.name}[/]' for label in data.labels))
 

--- a/tests/screens/test_create.py
+++ b/tests/screens/test_create.py
@@ -265,12 +265,16 @@ async def test_rendering(app, git_repository, helpers, mock_pull_requests):
         rendering = app.query_one(CandidateRendering)
         rendered_label = rendering.label.render()
         rendered_label_text = str(rendered_label)
-        assert rendered_label_text == ' #2 '
-        assert len(rendered_label.spans) == 1
+        assert rendered_label_text == ' #2 by username2 '
+        assert len(rendered_label.spans) == 2
         rendered_label_span = rendered_label.spans[0]
         assert rendered_label_span.start == 1
-        assert rendered_label_span.end == len(rendered_label_text) - 1
+        assert rendered_label_span.end == 3
         assert rendered_label_span.style == 'link https://github.com/org/repo/pull/2'
+        rendered_label_span = rendered_label.spans[1]
+        assert rendered_label_span.start == 7
+        assert rendered_label_span.end == len(rendered_label_text) - 1
+        assert rendered_label_span.style == 'link https://github.com/username2'
 
         rendered_title = rendering.title.render()
         assert isinstance(rendered_title, RichMarkdown)


### PR DESCRIPTION
# Problem

When we choose which team should QA a PR, we do not display the author of the PR, which could be useful. We have the info so it's pretty cheap to add this info

# What does this PR do?

Display the author with a link to its GitHub profile if we have the info

# Show time

| Before | After |
|--------|-------|
| ![before](https://github.com/DataDog/ddqa/assets/1266346/1d560730-2f01-4b98-a73d-679ff3af11b7)  |  ![after](https://github.com/DataDog/ddqa/assets/1266346/1247dc0c-042a-4d42-906b-751763191bd4)  |

![yeah-he-did-that-that-was-him](https://github.com/DataDog/ddqa/assets/1266346/8c80b346-d3d8-42dc-9db7-a1ea6094e502)

# Additional note

https://datadoghq.atlassian.net/browse/AITS-307