### PR TITLE
Make the team labels clickable in the create screen

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Only retrieve merged PRs when fetching them from GitHub
 - Add a set of commands to interact with the cache
 - Show the author of a PR on the create screen
+- Make the team labels clickable in the create screen
 
 ## 0.4.0 - 2023-06-21
 

--- a/src/ddqa/widgets/input.py
+++ b/src/ddqa/widgets/input.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 from rich.style import Style
+from textual import events
 from textual.containers import HorizontalScroll
 from textual.widgets import Label, Switch
 
@@ -22,16 +23,6 @@ class LabeledInput(HorizontalScroll):
         width: 5fr;
     }
     """
-
-
-class SwitchLabel(Label):
-    def __init__(self, label: str, switch: Switch) -> None:
-        super().__init__(label)
-        self.styles.text_style = Style(underline=True)
-        self.__switch = switch
-
-    def on_click(self):
-        self.__switch.action_toggle()
 
 
 class LabeledSwitch(HorizontalScroll):
@@ -55,6 +46,10 @@ class LabeledSwitch(HorizontalScroll):
 
     def __init__(self, *args, label: str, **kwargs):
         self.switch = Switch()
-        self.label = SwitchLabel(label, self.switch)
+        self.label = Label(label)
+        self.label.styles.text_style = Style(underline=True)
 
         super().__init__(self.switch, self.label, *args, **kwargs)
+
+    def _on_click(self, _event: events.Click) -> None:
+        self.switch.toggle()

--- a/src/ddqa/widgets/input.py
+++ b/src/ddqa/widgets/input.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present Datadog, Inc. <dev@datadoghq.com>
 #
 # SPDX-License-Identifier: MIT
+from rich.style import Style
 from textual.containers import HorizontalScroll
 from textual.widgets import Label, Switch
 
@@ -23,6 +24,16 @@ class LabeledInput(HorizontalScroll):
     """
 
 
+class SwitchLabel(Label):
+    def __init__(self, label: str, switch: Switch) -> None:
+        super().__init__(label)
+        self.styles.text_style = Style(underline=True)
+        self.__switch = switch
+
+    def on_click(self):
+        self.__switch.action_toggle()
+
+
 class LabeledSwitch(HorizontalScroll):
     DEFAULT_CSS = """
     LabeledSwitch {
@@ -43,7 +54,7 @@ class LabeledSwitch(HorizontalScroll):
     """
 
     def __init__(self, *args, label: str, **kwargs):
-        self.label = Label(label)
         self.switch = Switch()
+        self.label = SwitchLabel(label, self.switch)
 
         super().__init__(self.switch, self.label, *args, **kwargs)

--- a/tests/widgets/__init__.py
+++ b/tests/widgets/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT

--- a/tests/widgets/test_input.py
+++ b/tests/widgets/test_input.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2023-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from unittest.mock import MagicMock
+
+from ddqa.widgets.input import LabeledSwitch
+
+
+class TestLabeledSwitch:
+    async def test_click(self, app):  # noqa ARG002
+        labeled_switch = LabeledSwitch(label='label')
+
+        assert not labeled_switch.switch.value
+        labeled_switch._on_click(MagicMock())
+        assert labeled_switch.switch.value
+        labeled_switch._on_click(MagicMock())
+        assert not labeled_switch.switch.value


### PR DESCRIPTION
# Problem

In the create screen we have a couple of switches to choose which team(s) should QA the card. The switch is rather small and the labels are not clickable. I find it pretty annoying and it would be better from a UX perspective to be able to click on the label to toggle the switch

# What does this PR do?

When you click on a team label, it will toggle the corresponding switch

# Show time

| Before | After |
|--------|-------|
| ![before](https://github.com/DataDog/ddqa/assets/1266346/e3481740-0457-477f-a742-d7ded826e70f)  |  ![after](https://github.com/DataDog/ddqa/assets/1266346/98d5917f-aaf9-41d6-9788-d4a836778c42)  |

I swear I clicked on the labels in the "before" gif. 

![trust-me-on-this-okay-believe-in-me](https://github.com/DataDog/ddqa/assets/1266346/5fa0e504-1135-4acb-afb9-0c5494829c3d)

# Additional notes

https://datadoghq.atlassian.net/browse/AITS-308