### PR TITLE
Extract the cache functions from the GitHubRepository to its own class

### DIFF
--- a/src/ddqa/app/core.py
+++ b/src/ddqa/app/core.py
@@ -137,7 +137,7 @@ class Application(App):
 
     def needs_syncing(self) -> bool:
         return not self.github.load_global_config(str(self.repo.global_config_source)) or not any(
-            self.github.cache_dir_team_members.iterdir()
+            self.github.cache.cache_dir_team_members.iterdir()
         )
 
     def config_errors(self) -> list[str]:

--- a/src/ddqa/cache/__init__.py
+++ b/src/ddqa/cache/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT

--- a/src/ddqa/cache/github.py
+++ b/src/ddqa/cache/github.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: 2023-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import json
+from functools import cached_property
+from typing import TYPE_CHECKING, Any
+
+from ddqa.utils.fs import Path
+
+if TYPE_CHECKING:
+    from ddqa.utils.github import GitHubRepository
+
+
+class GitHubCache:
+    def __init__(self, cache_dir: Path, github_repo: GitHubRepository) -> None:
+        super().__init__()
+        self.__cache_dir = cache_dir
+        self.__github_repo = github_repo
+
+    @cached_property
+    def cache_dir(self) -> Path:
+        return self.__cache_dir / 'github' / self.__github_repo.org / self.__github_repo.repo_name
+
+    @cached_property
+    def cache_dir_commits(self) -> Path:
+        directory = self.cache_dir / 'commits'
+        directory.ensure_dir_exists()
+        return directory
+
+    @cached_property
+    def cache_dir_pull_requests(self) -> Path:
+        directory = self.cache_dir / 'pull_requests'
+        directory.ensure_dir_exists()
+        return directory
+
+    @cached_property
+    def cache_dir_team_members(self) -> Path:
+        directory = self.cache_dir / 'team_members'
+        directory.ensure_dir_exists()
+        return directory
+
+    @cached_property
+    def global_config_file(self) -> Path:
+        path = self.cache_dir / 'config.json'
+        path.parent.ensure_dir_exists()
+        return path
+
+    def save_global_config(self, source: str, global_config: dict[str, Any]) -> None:
+        data = {}
+        if self.global_config_file.is_file():
+            data.update(json.loads(self.global_config_file.read_text()))
+
+        data[source] = global_config
+        self.global_config_file.write_atomic(json.dumps(data), 'w', encoding='utf-8')
+
+    def get_team_members_file(self, team):
+        return self.cache_dir_team_members / f'{team}.txt'
+
+    def get_cached_candidate_data_from_commit(self, commit_hash: str):
+        directory = self.cache_dir_commits / commit_hash
+        if not directory.is_dir():
+            return
+
+        entries = list(directory.iterdir())
+        if not entries:
+            return
+
+        data = entries[0]
+        if data.stem == 'no_pr':
+            return json.loads(data.read_text())
+        elif (cached_candidate_data := self.cache_dir_pull_requests / f'{data.name}.json').is_file():
+            return json.loads(cached_candidate_data.read_text())
+
+    def get_cached_candidate_data_from_pr_number(self, number: str):
+        if (cached_candidate_data := self.cache_dir_pull_requests / f'{number}.json').is_file():
+            return json.loads(cached_candidate_data.read_text())
+
+    def duplicate_cached_candidate_data_from_pr_number(self, commit_hash: str, number: str):
+        directory = self.cache_dir_commits / commit_hash
+        directory.ensure_dir_exists()
+        (directory / number).touch()
+
+    def cache_candidate_data(self, commit_hash: str, candidate_data: dict):
+        directory = self.cache_dir_commits / commit_hash
+        directory.ensure_dir_exists()
+
+        if candidate_data['id'].isdigit():
+            (self.cache_dir_pull_requests / f'{candidate_data["id"]}.json').write_text(json.dumps(candidate_data))
+            (directory / candidate_data['id']).touch()
+        else:
+            (directory / 'no_pr.json').write_text(json.dumps(candidate_data))

--- a/src/ddqa/screens/sync.py
+++ b/src/ddqa/screens/sync.py
@@ -72,7 +72,7 @@ class InteractiveSidebar(Widget):
                 status.update('No members found in TOML source')
                 return
 
-            self.app.github.save_global_config(self.app.repo.global_config_source, global_config)
+            self.app.github.cache.save_global_config(self.app.repo.global_config_source, global_config)
 
             teams = sorted(team.github_team for team in self.app.repo.teams.values())
             for team in teams:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ class TestApplication(Application):
 
         if github_teams is not None:
             for team, members in github_teams.items():
-                (self.github.cache_dir_team_members / f'{team}.txt').write_text('\n'.join(members))
+                (self.github.cache.cache_dir_team_members / f'{team}.txt').write_text('\n'.join(members))
 
     def save_repo_config(self, repo_config: dict[str, Any]) -> None:
         Path(self.repo.path, '.ddqa', 'config.toml').write_text(tomli_w.dumps(repo_config))


### PR DESCRIPTION
# Context 

See https://github.com/DataDog/ddqa/pull/64 to see exactly what I'm trying to achieve, but the current PR needs to be merged first to make the second one possible.

# Problem

We have a cache inside the GitHubRepository class to avoid fetching the same PR from GitHub over and over again. Most of the methods related to the cache are private. I'd need to access this cache from outside.

Disclaimer: I know this is not a perfect solution and one could argue that the outside world should not care about the cache. If you think of a better approach let me know, we could implement that step by step.

# What does this PR do?

- Extract all the cache related functions from the GitHubRepository to a GitHubCache
- Add a new attribute to the GitHubRepository that stores the GitHubCache and make use of it
- Update the rest of the code and tests accordingly

# Additional notes

- I'm not adding new code here, I'm just moving stuff around. The current tests will make sure the app is still working properly

Relates to https://datadoghq.atlassian.net/browse/AITS-206