### PR TITLE
Save and restore the assigned teams to the PRs in the create screen

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Show the author of a PR on the create screen
 - Make the team labels clickable in the create screen
 - Do not show PRs that have a ignored label in the create screen
+- Save and restore the assigned teams to PRs in the create screen
 
 ## 0.4.0 - 2023-06-21
 

--- a/src/ddqa/cache/github.py
+++ b/src/ddqa/cache/github.py
@@ -13,6 +13,11 @@ if TYPE_CHECKING:
     from ddqa.utils.github import GitHubRepository
 
 
+class SetEncoder(json.JSONEncoder):
+    def default(self, obj):
+        return list(obj)
+
+
 class GitHubCache:
     def __init__(self, cache_dir: Path, github_repo: GitHubRepository) -> None:
         super().__init__()
@@ -87,7 +92,9 @@ class GitHubCache:
         directory.ensure_dir_exists()
 
         if candidate_data['id'].isdigit():
-            (self.cache_dir_pull_requests / f'{candidate_data["id"]}.json').write_text(json.dumps(candidate_data))
+            (self.cache_dir_pull_requests / f'{candidate_data["id"]}.json').write_text(
+                json.dumps(candidate_data, cls=SetEncoder)
+            )
             (directory / candidate_data['id']).touch()
         else:
-            (directory / 'no_pr.json').write_text(json.dumps(candidate_data))
+            (directory / 'no_pr.json').write_text(json.dumps(candidate_data, cls=SetEncoder))

--- a/src/ddqa/models/github.py
+++ b/src/ddqa/models/github.py
@@ -24,6 +24,7 @@ class TestCandidate(BaseModel):
     body: str = ''
     labels: list[PullRequestLabel] = []
     reviewers: list[PullRequestReviewer] = []
+    assigned_teams: set[str] = set()
 
     def short_display(self) -> str:
         return f'#{self.id}' if self.id.isdigit() else self.id[:7]

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -9,6 +9,7 @@ import pytest
 from httpx import Request, Response
 from textual.widgets import Static
 
+from ddqa.models.github import TestCandidate as Candidate
 from ddqa.utils.git import GitCommit
 from ddqa.utils.network import ResponsiveNetworkClient
 
@@ -110,6 +111,7 @@ class TestCandidates:
                 {'name': 'username1', 'association': 'member'},
                 {'name': 'username2', 'association': 'collaborator'},
             ],
+            'assigned_teams': set(),
         }
 
     async def test_get_candidates(self, app, git_repository, mocker):
@@ -184,18 +186,20 @@ class TestCandidates:
         assert len(candidates) == 1
         assert candidates == [
             (
-                {
-                    'id': '123',
-                    'title': 'title123',
-                    'url': 'https://github.com/org/repo/pull/123',
-                    'user': 'username123',
-                    'labels': [{'name': 'label1', 'color': '632ca6'}, {'name': 'label2', 'color': '632ca6'}],
-                    'body': 'foo\nbar',
-                    'reviewers': [
-                        {'name': 'username1', 'association': 'member'},
-                        {'name': 'username2', 'association': 'collaborator'},
-                    ],
-                },
+                Candidate(
+                    **{
+                        'id': '123',
+                        'title': 'title123',
+                        'url': 'https://github.com/org/repo/pull/123',
+                        'user': 'username123',
+                        'labels': [{'name': 'label1', 'color': '632ca6'}, {'name': 'label2', 'color': '632ca6'}],
+                        'body': 'foo\nbar',
+                        'reviewers': [
+                            {'name': 'username1', 'association': 'member'},
+                            {'name': 'username2', 'association': 'collaborator'},
+                        ],
+                    }
+                ),
                 0,
                 0,
             )
@@ -309,6 +313,7 @@ class TestCandidates:
             'labels': [],
             'body': '',
             'reviewers': [],
+            'assigned_teams': set(),
         }
 
     async def test_get_candidates_no_pr(self, app, git_repository, mocker):
@@ -353,6 +358,7 @@ class TestCandidates:
                     'labels': [],
                     'body': '',
                     'reviewers': [],
+                    'assigned_teams': set(),
                 },
                 0,
                 0,
@@ -395,6 +401,7 @@ class TestCandidates:
             'labels': [],
             'body': '',
             'reviewers': [],
+            'assigned_teams': set(),
         }
 
         # First encounter of a candidate with a PR
@@ -465,6 +472,7 @@ class TestCandidates:
                 {'name': 'username1', 'association': 'member'},
                 {'name': 'username2', 'association': 'collaborator'},
             ],
+            'assigned_teams': set(),
         }
 
         # First encounter of a candidate with a PR that has already been seen
@@ -498,6 +506,7 @@ class TestCandidates:
                 {'name': 'username1', 'association': 'member'},
                 {'name': 'username2', 'association': 'collaborator'},
             ],
+            'assigned_teams': set(),
         }
 
         assert repo_cache_dir.is_dir()
@@ -554,6 +563,7 @@ class TestCandidates:
             'labels': [],
             'body': '',
             'reviewers': [],
+            'assigned_teams': set(),
         }
         candidate = await app.github.get_candidate(
             ResponsiveNetworkClient(Static()), GitCommit(hash='hash2', subject='subject2')
@@ -570,6 +580,7 @@ class TestCandidates:
                 {'name': 'username1', 'association': 'member'},
                 {'name': 'username2', 'association': 'collaborator'},
             ],
+            'assigned_teams': set(),
         }
         candidate = await app.github.get_candidate(
             ResponsiveNetworkClient(Static()), GitCommit(hash='hash3', subject='subject3')
@@ -586,6 +597,7 @@ class TestCandidates:
                 {'name': 'username1', 'association': 'member'},
                 {'name': 'username2', 'association': 'collaborator'},
             ],
+            'assigned_teams': set(),
         }
 
 
@@ -810,4 +822,5 @@ async def test_rate_limit_handling(app, git_repository, mocker):
             {'name': 'username1', 'association': 'member'},
             {'name': 'username2', 'association': 'collaborator'},
         ],
+        'assigned_teams': set(),
     }


### PR DESCRIPTION
# Context

This PR depends on https://github.com/DataDog/ddqa/pull/63 and needs it to be merged first. I opened the current PR to show exactly why the refactor was needed.

# Problem

The create screen does not save the assignments the user made. If for some reasons the user closes ddqa and open it again, all the assignments are lost. 

# What does this PR do?

- When the user assigns a team to a given PR, we save this info in the cache we already have
- When we load the screen, we read the PRs from the cache and retrieve the already assigned teams for each PR

# Show time

| Before | After |
|--------|-------|
| ![before](https://github.com/DataDog/ddqa/assets/1266346/08f8341f-0012-4feb-9ae6-5dff0f1d164b) | ![after](https://github.com/DataDog/ddqa/assets/1266346/c5055955-bda8-4319-aef1-e8abf034d61c)  |

# Additional note

Relates to https://datadoghq.atlassian.net/browse/AITS-206