### PR TITLE
Fix a bug that prevents the on_change event to be propagated back to the screen

### DIFF
--- a/src/ddqa/widgets/input.py
+++ b/src/ddqa/widgets/input.py
@@ -1,8 +1,9 @@
 # SPDX-FileCopyrightText: 2023-present Datadog, Inc. <dev@datadoghq.com>
 #
 # SPDX-License-Identifier: MIT
+from collections.abc import Callable
+
 from rich.style import Style
-from textual import events
 from textual.containers import HorizontalScroll
 from textual.widgets import Label, Switch
 
@@ -23,6 +24,16 @@ class LabeledInput(HorizontalScroll):
         width: 5fr;
     }
     """
+
+
+class ClickableLabel(Label):
+    def __init__(self, label: str, callback: Callable[[], None]) -> None:
+        super().__init__(label)
+        self.styles.text_style = Style(underline=True)
+        self.__callback = callback
+
+    def on_click(self):
+        self.__callback()
 
 
 class LabeledSwitch(HorizontalScroll):
@@ -46,10 +57,6 @@ class LabeledSwitch(HorizontalScroll):
 
     def __init__(self, *args, label: str, **kwargs):
         self.switch = Switch()
-        self.label = Label(label)
-        self.label.styles.text_style = Style(underline=True)
+        self.label = ClickableLabel(label, self.switch.action_toggle)
 
         super().__init__(self.switch, self.label, *args, **kwargs)
-
-    def _on_click(self, _event: events.Click) -> None:
-        self.switch.toggle()

--- a/tests/widgets/test_input.py
+++ b/tests/widgets/test_input.py
@@ -3,7 +3,23 @@
 # SPDX-License-Identifier: MIT
 from unittest.mock import MagicMock
 
-from ddqa.widgets.input import LabeledSwitch
+from ddqa.widgets.input import ClickableLabel, LabeledSwitch
+
+
+class TestClickableSwitch:
+    async def test_click(self, app):  # noqa ARG002
+        mock = MagicMock()
+        labeled_switch = ClickableLabel(label='label', callback=mock.callback)
+
+        assert not mock.callback.called
+        labeled_switch.on_click()
+        assert mock.callback.called
+        assert mock.callback.call_count == 1
+
+        labeled_switch.on_click()
+        labeled_switch.on_click()
+        assert mock.callback.called
+        assert mock.callback.call_count == 3
 
 
 class TestLabeledSwitch:
@@ -11,7 +27,7 @@ class TestLabeledSwitch:
         labeled_switch = LabeledSwitch(label='label')
 
         assert not labeled_switch.switch.value
-        labeled_switch._on_click(MagicMock())
+        labeled_switch.label.on_click()
         assert labeled_switch.switch.value
-        labeled_switch._on_click(MagicMock())
+        labeled_switch.label.on_click()
         assert not labeled_switch.switch.value


### PR DESCRIPTION
In fact [this solution](https://github.com/DataDog/ddqa/pull/62/commits/e3b7b77295c8d2e92dc08bad9e62635173204fad#r1393975760) does not work completely. The Changed event is not correctly propagated back to the screen and we do not update the status in the widget on the left :sad:

| Before | After |
|--------|-------|
| ![before](https://github.com/DataDog/ddqa/assets/1266346/06b4508f-0539-4956-abc8-8afcf680f93d) | ![after](https://github.com/DataDog/ddqa/assets/1266346/d51fb357-a8e7-4741-b33d-55c5b5030c05) |

![crying-trust](https://github.com/DataDog/ddqa/assets/1266346/e47760ce-7fce-43a2-9efb-3d7e062bff7f)

https://datadoghq.atlassian.net/browse/AITS-308