### PR TITLE
Configure GitHub and Jira credentials from environment variables

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Make the team labels clickable in the create screen
 - Do not show PRs that have a ignored label in the create screen
 - Save and restore the assigned teams to PRs in the create screen
+- Allow users to configure their GitHub and Jira credentials with environment variables
 
 ## 0.4.0 - 2023-06-21
 

--- a/docs/config/user.md
+++ b/docs/config/user.md
@@ -29,6 +29,9 @@ The following APIs are used:
     ??? note
         This endpoint is [not yet supported](https://docs.github.com/en/rest/overview/endpoints-available-for-fine-grained-personal-access-tokens?apiVersion=2022-11-28) when using fine-grained personal access tokens.
 
+!!! tip
+    You can configure your GitHub credentials using the `DDQA_GITHUB_USER` and `DDQA_GITHUB_TOKEN` environment variables.
+
 ## Jira auth
 
 You'll need to create an [API token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/) with the appropriate scopes.
@@ -39,3 +42,6 @@ The following APIs are used:
 - `/rest/api/2/myself` ([GET](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-myself/#api-rest-api-2-myself-get))
 - `/rest/api/2/search` ([POST](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-search/#api-rest-api-2-search-post))
 - `/rest/api/2/issue/{issueIdOrKey}/transitions` ([GET](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/#api-rest-api-2-issue-issueidorkey-transitions-get), [POST](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/#api-rest-api-2-issue-issueidorkey-transitions-post))
+
+!!! tip
+    You can configure your Jira credentials using the `DDQA_JIRA_EMAIL` and `DDQA_JIRA_TOKEN` environment variables.

--- a/src/ddqa/models/config/auth.py
+++ b/src/ddqa/models/config/auth.py
@@ -1,19 +1,23 @@
 # SPDX-FileCopyrightText: 2023-present Datadog, Inc. <dev@datadoghq.com>
 #
 # SPDX-License-Identifier: MIT
-from __future__ import annotations
-
-from pydantic import BaseModel
+from pydantic import BaseModel, BaseSettings
 
 
-class GitHubAuth(BaseModel):
+class GitHubAuth(BaseSettings):  # type: ignore
     user: str
     token: str
 
+    class Config:
+        env_prefix = 'DDQA_GITHUB_'
 
-class JiraAuth(BaseModel):
+
+class JiraAuth(BaseSettings):  # type: ignore
     email: str
     token: str
+
+    class Config:
+        env_prefix = 'DDQA_JIRA_'
 
 
 class AuthConfig(BaseModel):

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT

--- a/tests/data/test_auth.py
+++ b/tests/data/test_auth.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2023-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from ddqa.models.config.auth import GitHubAuth, JiraAuth
+from ddqa.utils.structures import EnvVars
+
+
+class TestGitHubAuth:
+    def test_load_from_env_variables(self):
+        with EnvVars({'DDQA_GITHUB_USER': 'my_user', 'DDQA_GITHUB_TOKEN': 'my_token'}):
+            auth = GitHubAuth()
+            assert auth.user == 'my_user'
+            assert auth.token == 'my_token'
+
+
+class TestJiraAuth:
+    def test_load_from_env_variables(self):
+        with EnvVars({'DDQA_JIRA_EMAIL': 'my_email', 'DDQA_JIRA_TOKEN': 'my_token'}):
+            auth = JiraAuth()
+            assert auth.email == 'my_email'
+            assert auth.token == 'my_token'


### PR DESCRIPTION
# Problem

Users would like to be able to store their Jira and GitHub credentials in environment variables. 

# What does this PR do?

Load the credentials from the environment variables `DDQA_JIRA_TOKEN`, `DDQA_JIRA_EMAIL`, `DDQA_GITHUB_TOKEN` and `DDQA_GITHUB_USER`

# Additional notes

https://datadoghq.atlassian.net/browse/AITS-310