### PR TITLE
Add tooltips in the create screen

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Save and restore the assigned teams to PRs in the create screen
 - Allow users to configure their GitHub and Jira credentials with environment variables
 - Add a refresh button to the status screen
+- Add tooltips and a scroll bar in the create screen on the PR title and labels
 
 ## 0.4.0 - 2023-06-21
 

--- a/src/ddqa/screens/create.py
+++ b/src/ddqa/screens/create.py
@@ -371,7 +371,7 @@ class CandidateRendering(LabeledBox):
 
         super().__init__(
             '',
-            Container(self.__title, self.__labels, id='candidate-info'),
+            Container(self.__title, HorizontalScroll(self.__labels), id='candidate-info'),
             self.__body,
             self.__candidate_assignments,
         )
@@ -412,7 +412,11 @@ class CandidateRendering(LabeledBox):
 
         self.label.update(label)
         self.title.update(RichMarkdown(data.title))
-        self.labels.update(' '.join(f'[black on #{label.color}]{label.name}[/]' for label in data.labels))
+        self.title.tooltip = data.title
+
+        labels = ' '.join(f'[black on #{label.color}]{label.name}[/]' for label in data.labels)
+        self.labels.update(labels)
+        self.labels.tooltip = labels or None
 
         if data.id in self.__body_renderings:
             body_rendering = self.__body_renderings[data.id]


### PR DESCRIPTION
# Problem

When the screen is too small or if we have too many labels, some of them are hidden and the user can't see them all.

# What does this PR do?

- Add a tooltip on the labels (and also on the title) of a given PR so the user can see them all if some of them are hidden
- Also add a horizontal scroll bar when needed

# Show time

| Before | After |
|--------|-------|
| ![before](https://github.com/DataDog/ddqa/assets/1266346/8a58c2e1-b953-4c0d-b543-33e60b1d2815)  | ![after](https://github.com/DataDog/ddqa/assets/1266346/1998cdea-f6aa-49eb-9933-b11892628342) |

# Additional notes

https://datadoghq.atlassian.net/browse/AITS-207