### PR TITLE
Check the status of the users in Jira in the sync command

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Allow users to configure their GitHub and Jira credentials with environment variables
 - Add a refresh button to the status screen
 - Add tooltips and a scroll bar in the create screen on the PR title and labels
+- Check the status of the users in Jira in the sync command
 
 ## 0.4.0 - 2023-06-21
 

--- a/src/ddqa/screens/sync.py
+++ b/src/ddqa/screens/sync.py
@@ -83,6 +83,21 @@ class InteractiveSidebar(Widget):
                     status.update(str(e))
                     return
 
+            text_log.write(f'Validating {len(global_config.get("members", {}))} Jira users...', shrink=False)
+            try:
+                members_rev = {v: k for k, v in global_config.get('members', {}).items()}
+
+                async for jira_user in self.app.jira.get_deactivated_users(
+                    client, global_config.get('members', {}).values()
+                ):
+                    text_log.write(f'User {members_rev[jira_user["accountId"]]} is deactivated on Jira', shrink=False)
+                    del global_config['members'][members_rev[jira_user['accountId']]]
+
+                self.app.github.cache.save_global_config(self.app.repo.global_config_source, global_config)
+            except Exception as e:
+                status.update(str(e))
+                return
+
             button.disabled = False
 
     async def on_button_pressed(self, _event: Button.Pressed) -> None:

--- a/tests/screens/test_sync.py
+++ b/tests/screens/test_sync.py
@@ -205,6 +205,31 @@ async def test_save_teams(app, git_repository, helpers, mocker):
             ),
         ],
     )
+    mocker.patch(
+        'httpx.AsyncClient.request',
+        side_effect=[
+            Response(
+                200,
+                request=Request('GET', ''),
+                content=json.dumps(
+                    {
+                        'maxResults': 100,
+                        'startAt': 0,
+                        'total': 1,
+                        'values': [
+                            {
+                                'self': 'https://your-domain.atlassian.net/rest/api/2/user?accountId=f',
+                                'accountId': 'j',
+                                'accountType': 'atlassian',
+                                'emailAddress': 'j@example.com',
+                                'active': True,
+                            },
+                        ],
+                    },
+                ),
+            ),
+        ],
+    )
     repo_config = dict(app.repo.dict())
     repo_config['teams'] = {
         'foo': {
@@ -234,6 +259,7 @@ async def test_save_teams(app, git_repository, helpers, mocker):
             Fetching global config from: {app.repo.global_config_source}
             Refreshing members for team: bar-team
             Refreshing members for team: foo-team
+            Validating 1 Jira users...
             """
         )
 
@@ -243,4 +269,111 @@ async def test_save_teams(app, git_repository, helpers, mocker):
         assert app.github.load_global_config(app.repo.global_config_source) == {
             'jira_server': 'https://foo.atlassian.net',
             'members': {'g': 'j'},
+        }
+
+
+async def test_deactivated_jira_user(app, git_repository, helpers, mocker):
+    app.configure(
+        git_repository,
+        caching=True,
+        data={'github': {'user': 'foo', 'token': 'bar'}, 'jira': {'email': 'foo@bar.baz', 'token': 'bar'}},
+    )
+    mocker.patch(
+        'httpx.AsyncClient.get',
+        side_effect=[
+            Response(
+                200,
+                request=Request('GET', ''),
+                content=helpers.dedent(
+                    """
+                    jira_server = "https://foo.atlassian.net"
+
+                    [members]
+                    g = "j"
+                    """
+                ),
+            ),
+            Response(
+                200,
+                request=Request('GET', ''),
+                content=json.dumps(
+                    [
+                        {'login': 'foo1', 'type': 'User'},
+                        {'login': 'bot', 'type': 'other'},
+                    ],
+                ),
+            ),
+            Response(
+                200,
+                request=Request('GET', ''),
+                content=json.dumps(
+                    [
+                        {'login': 'bar1', 'type': 'User'},
+                        {'login': 'bot', 'type': 'other'},
+                    ],
+                ),
+            ),
+        ],
+    )
+    mocker.patch(
+        'httpx.AsyncClient.request',
+        side_effect=[
+            Response(
+                200,
+                request=Request('GET', ''),
+                content=json.dumps(
+                    {
+                        'maxResults': 100,
+                        'startAt': 0,
+                        'total': 1,
+                        'values': [
+                            {
+                                'self': 'https://your-domain.atlassian.net/rest/api/2/user?accountId=f',
+                                'accountId': 'j',
+                                'accountType': 'atlassian',
+                                'emailAddress': 'j@example.com',
+                                'active': False,
+                            },
+                        ],
+                    },
+                ),
+            ),
+        ],
+    )
+    repo_config = dict(app.repo.dict())
+    repo_config['teams'] = {
+        'foo': {
+            'jira_project': 'FOO',
+            'jira_issue_type': 'Foo-Task',
+            'jira_statuses': {'TODO': 'Backlog', 'IN PROGRESS': 'Sprint', 'DONE': 'Done'},
+            'github_team': 'foo-team',
+        },
+        'bar': {
+            'jira_project': 'BAR',
+            'jira_issue_type': 'Bar-Task',
+            'jira_statuses': {'TODO': 'Backlog', 'IN PROGRESS': 'Sprint', 'DONE': 'Done'},
+            'github_team': 'bar-team',
+        },
+    }
+    app.save_repo_config(repo_config)
+
+    async with app.run_test():
+        sidebar = app.query_one(InteractiveSidebar)
+        text_log = sidebar.query_one(RichLog)
+        assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
+            f"""
+            Fetching global config from: {app.repo.global_config_source}
+            Refreshing members for team: bar-team
+            Refreshing members for team: foo-team
+            Validating 1 Jira users...
+            User g is deactivated on Jira
+            """
+        )
+
+        button = sidebar.query_one(Button)
+        assert not button.disabled
+
+        assert app.github.load_global_config(app.repo.global_config_source) == {
+            'jira_server': 'https://foo.atlassian.net',
+            'members': {},
         }


### PR DESCRIPTION
# Problem

The `sync` command does not check if the users that are specified in https://github.com/DataDog/github-metadata/blob/master/jira.toml are still valid in Jira. This leads us to load users that can not be assigned to QA cards

# What does this PR do?

- At the end of the sync command, fetch the users from Jira and drop the deactivated ones from the list that is cached

# Show time

| Before | After |
|--------|-------|
| ![before](https://github.com/DataDog/ddqa/assets/1266346/662ea18b-f090-4781-90af-b7a2280e448a) | ![after](https://github.com/DataDog/ddqa/assets/1266346/763d5768-fab4-419f-a12b-a543269a0401) |

# Additional notes

https://datadoghq.atlassian.net/browse/AITS-215