### PR TITLE
Add direct links to GitHub and Jira in the sync screen

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add a refresh button to the status screen
 - Add tooltips and a scroll bar in the create screen on the PR title and labels
 - Check the status of the users in Jira in the sync command
+- Add direct links to GitHub and Jira in the sync screen
 
 ## 0.4.0 - 2023-06-21
 


### PR DESCRIPTION
# Problem

In [this PR](https://github.com/DataDog/ddqa/pull/70) I added a check on Jira users. Thanks to that, I wanted to update the config file to drop the users that are deactivated, but before that I wanted to double check they are not part of the org on GitHub and see their profile on Jira. I had no way to do that easily.

# What does this PR do?

- Add a link to the config file
- Add a link to the GitHub teams
- Add a link to the GitHub and Jira profiles of a deactivated user

# Show time

| Before | After |
|--------|-------|
| ![before](https://github.com/DataDog/ddqa/assets/1266346/be34e058-4d0b-4a88-9d2f-ba75cb320224) | ![after](https://github.com/DataDog/ddqa/assets/1266346/9940eb34-d0fd-45b3-bf76-78fbd24c71c9) |

# Additional notes

- https://datadoghq.atlassian.net/browse/AITS-215