### PR TITLE
Refactor the GitHub team cache

### DIFF
--- a/src/ddqa/cache/github.py
+++ b/src/ddqa/cache/github.py
@@ -98,3 +98,12 @@ class GitHubCache:
             (directory / candidate_data['id']).touch()
         else:
             (directory / 'no_pr.json').write_text(json.dumps(candidate_data, cls=SetEncoder))
+
+    def get_team_members(self, team: str) -> set[str] | None:
+        if (members_file := self.get_team_members_file(team)).is_file():
+            return set(members_file.read_text().splitlines())
+
+        return None
+
+    def save_team_members(self, team: str, members: set[str]) -> None:
+        self.get_team_members_file(team).write_text('\n'.join(members))

--- a/src/ddqa/cache/github.py
+++ b/src/ddqa/cache/github.py
@@ -100,7 +100,9 @@ class GitHubCache:
             (directory / 'no_pr.json').write_text(json.dumps(candidate_data, cls=SetEncoder))
 
     def get_team_members(self, team: str) -> set[str] | None:
-        if (members_file := self.get_team_members_file(team)).is_file():
+        members_file = self.get_team_members_file(team)
+
+        if members_file.is_file():
             return set(members_file.read_text().splitlines())
 
         return None

--- a/tests/cache/__init__.py
+++ b/tests/cache/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT

--- a/tests/cache/test_github.py
+++ b/tests/cache/test_github.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2023-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+
+
+class TestTeamMembers:
+    def test_get_no_cache(self, github_cache):
+        assert github_cache.get_team_members('random') is None
+
+    def test_read(self, github_cache):
+        assert github_cache.get_team_members('random') is None
+        github_cache.get_team_members_file('random').write_text('m1\nm2')
+        assert {'m1', 'm2'} == github_cache.get_team_members('random')
+
+    def test_write(self, github_cache):
+        assert github_cache.get_team_members('random') is None
+        github_cache.save_team_members('random', {'m1', 'm2'})
+        assert github_cache.get_team_members_file('random').read_text() in ('m1\nm2', 'm2\nm1')
+
+    def test_write_read(self, github_cache):
+        github_cache.save_team_members('random', {'m1', 'm2'})
+        assert {'m1', 'm2'} == github_cache.get_team_members('random')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,12 +11,14 @@ import subprocess
 from collections.abc import Generator
 from tempfile import TemporaryDirectory
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 import tomli_w
 from click.testing import CliRunner
 
 from ddqa.app.core import Application
+from ddqa.cache.github import GitHubCache
 from ddqa.config.constants import AppEnvVars, ConfigEnvVars
 from ddqa.config.file import ConfigFile
 from ddqa.utils.fs import Path
@@ -176,3 +178,11 @@ def handle_remove_readonly(func, path, exc):  # no cov
         func(path)
     else:
         raise
+
+
+@pytest.fixture
+def github_cache(temp_dir):
+    github_repo = MagicMock()
+    github_repo.org = 'Datadog'
+    github_repo.repo_name = 'test-repo'
+    return GitHubCache(temp_dir, github_repo)

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -670,7 +670,7 @@ class TestTeamMembers:
 
         members_file = entries[0]
         assert members_file.name == 'a-team.txt'
-        assert members_file.read_text() == 'foo\nbar\nbaz'
+        assert set(members_file.read_text().splitlines()) == team_members
 
         response_mock = mocker.patch('httpx.AsyncClient.get', return_value=Response(500, request=Request('GET', '')))
 
@@ -717,7 +717,7 @@ class TestTeamMembers:
 
         members_file = entries[0]
         assert members_file.name == 'a-team.txt'
-        assert members_file.read_text() == 'foo\nbar\nbaz'
+        assert set(members_file.read_text().splitlines()) == team_members
 
         response_mock = mocker.patch(
             'httpx.AsyncClient.get',


### PR DESCRIPTION
# What does this PR do?

- Tiny refactor to extract some logic only related to the cache to its own class to avoid having it in the github client itself
- Add more test to the cache itself and update the existing tests accordingly

# Additional notes

- This PR does not change the behaviour of the application at all 
- Kinda relates to https://datadoghq.atlassian.net/browse/AITS-314 because I noticed this working on it