### PR TITLE
Add a upper bound for the textual dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "platformdirs",
   "pydantic<2",
   "rich",
-  "textual>=0.32.0,<=0.42.0",
+  "textual>=0.32.0,<0.42.0",
   "tomli-w",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "platformdirs",
   "pydantic<2",
   "rich",
-  "textual>=0.32.0",
+  "textual>=0.32.0,<=0.42.0",
   "tomli-w",
 ]
 


### PR DESCRIPTION
The [latest release](https://github.com/Textualize/textual/releases/tag/v0.42.0) broke our tests. Pin it for now, I'll have a look later

Created https://datadoghq.atlassian.net/browse/AITS-316 to investigate