### PR TITLE
Bump the textual version to 0.42.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "platformdirs",
   "pydantic<2",
   "rich",
-  "textual>=0.32.0,<0.42.0",
+  "textual==0.42.0",
   "tomli-w",
 ]
 

--- a/tests/screens/test_status.py
+++ b/tests/screens/test_status.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2023-present Datadog, Inc. <dev@datadoghq.com>
 #
 # SPDX-License-Identifier: MIT
+from textual.widgets import Select
+
 from ddqa.models.jira import JiraIssue
 from ddqa.screens.status import FilterSelect, IssueFilter
 
@@ -19,4 +21,4 @@ class TestFilterSelect:
 
         select = FilterSelect(dummy_filter)
 
-        assert select._initial_options == [('a', 'a'), ('b', 'b'), ('c', 'c'), ('z', 'z')]
+        assert select._options == [('', Select.BLANK), ('a', 'a'), ('b', 'b'), ('c', 'c'), ('z', 'z')]


### PR DESCRIPTION
# Context 

A new version of [textual](https://pypi.org/project/textual/) is out 🎉 

# What does this PR do?

- Upgrade and pin the version to 0.42.0
- Fix a unit test to work with this new version

# Additional notes

Relates to https://datadoghq.atlassian.net/browse/AITS-316