### PR TITLE
Pin the dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,14 +25,14 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "click>=8.1.3",
-  "httpx",
-  "pillow",
-  "platformdirs",
-  "pydantic<2",
-  "rich",
+  "click==8.1.7",
+  "httpx==0.25.2",
+  "pillow==10.1.0",
+  "platformdirs==4.0.0",
+  "pydantic==1.10.13",
+  "rich==13.7.0",
   "textual==0.42.0",
-  "tomli-w",
+  "tomli-w==1.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Pin all the dependencies to avoid breaking the application unexpectedly. I think we can rely on dependabot and the CI to keep our deps up-to-date, our test suite starts to get robust enough to catch most of the issues. 