### PR TITLE
Run dependabot at least once a week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
 - package-ecosystem: github-actions
-  directory: /
+  directory: "/"
   schedule:
-    interval: monthly
+    interval: "weekly"


### PR DESCRIPTION
I [pinned the deps](https://github.com/DataDog/ddqa/pull/80) so I'm configuring dependabot to run at least once a week to notify us of new versions sooner