### PR TITLE
Add a `pr_labels` option to the create command

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Check the status of the users in Jira in the sync command
 - Add direct links to GitHub and Jira in the sync screen
 - Check GitHub users are declared in the Jira config file in the sync screen
+- Add an `include_labels` option to only show PRs which have on of these labels in the create screen
 
 ## 0.4.0 - 2023-06-21
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -31,7 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Check the status of the users in Jira in the sync command
 - Add direct links to GitHub and Jira in the sync screen
 - Check GitHub users are declared in the Jira config file in the sync screen
-- Add an `include_labels` option to only show PRs which have on of these labels in the create screen
+- Add a `pr_labels` option to only show PRs which have on of these labels in the create screen
 
 ## 0.4.0 - 2023-06-21
 

--- a/src/ddqa/cli/create/__init__.py
+++ b/src/ddqa/cli/create/__init__.py
@@ -22,10 +22,27 @@ if TYPE_CHECKING:
     multiple=True,
     help='Labels that will be attached to created issues',
 )
+@click.option(
+    '-i',
+    '--include-labels',
+    'include_labels',
+    required=False,
+    multiple=True,
+    help='Labels that will be attached to created issues',
+)
 @click.pass_obj
-def create(app: Application, previous_ref: str, current_ref: str, labels: tuple[str, ...]):
+def create(
+    app: Application,
+    previous_ref: str,
+    current_ref: str,
+    labels: tuple[str, ...],
+    include_labels: list[str] | None = None,
+):
     """Create QA items."""
     from ddqa.screens.create import CreateScreen
 
-    app.select_screen('create', CreateScreen(previous_ref, current_ref, labels))
+    if not include_labels:
+        include_labels = app.config.app.include_labels
+
+    app.select_screen('create', CreateScreen(previous_ref, current_ref, labels, include_labels))
     app.run()

--- a/src/ddqa/cli/create/__init__.py
+++ b/src/ddqa/cli/create/__init__.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     'include_labels',
     required=False,
     multiple=True,
-    help='Labels that will be attached to created issues',
+    help='Labels that should be present in the PRs',
 )
 @click.pass_obj
 def create(

--- a/src/ddqa/cli/create/__init__.py
+++ b/src/ddqa/cli/create/__init__.py
@@ -23,9 +23,8 @@ if TYPE_CHECKING:
     help='Labels that will be attached to created issues',
 )
 @click.option(
-    '-i',
-    '--include-labels',
-    'include_labels',
+    '-pl',
+    '--pr-labels',
     required=False,
     multiple=True,
     help='Labels that should be present in the PRs',
@@ -36,13 +35,13 @@ def create(
     previous_ref: str,
     current_ref: str,
     labels: tuple[str, ...],
-    include_labels: list[str] | None = None,
+    pr_labels: list[str] | None = None,
 ):
     """Create QA items."""
     from ddqa.screens.create import CreateScreen
 
-    if not include_labels:
-        include_labels = app.config.app.include_labels
+    if not pr_labels:
+        pr_labels = app.config.app.pr_labels
 
-    app.select_screen('create', CreateScreen(previous_ref, current_ref, labels, include_labels))
+    app.select_screen('create', CreateScreen(previous_ref, current_ref, labels, pr_labels))
     app.run()

--- a/src/ddqa/models/config/app.py
+++ b/src/ddqa/models/config/app.py
@@ -9,4 +9,4 @@ from pydantic import BaseModel
 class AppConfig(BaseModel):
     repo: str = ''
     cache_dir: str = ''
-    include_labels: list[str] = []
+    pr_labels: list[str] = []

--- a/src/ddqa/models/config/app.py
+++ b/src/ddqa/models/config/app.py
@@ -9,3 +9,4 @@ from pydantic import BaseModel
 class AppConfig(BaseModel):
     repo: str = ''
     cache_dir: str = ''
+    include_labels: list[str] = []

--- a/src/ddqa/screens/create.py
+++ b/src/ddqa/screens/create.py
@@ -81,7 +81,7 @@ class CandidateListing(DataTable):
         previous_ref: str,
         current_ref: str,
         labels: tuple[str, ...],
-        include_labels: list[str] | None = None,
+        pr_labels: list[str] | None = None,
         *args,
         **kwargs,
     ):
@@ -91,7 +91,7 @@ class CandidateListing(DataTable):
         self.previous_ref = previous_ref
         self.current_ref = current_ref
         self.labels = labels
-        self.include_labels = include_labels
+        self.pr_labels = pr_labels
 
         self.candidates: dict[int, Candidate] = {}
 
@@ -130,7 +130,7 @@ class CandidateListing(DataTable):
                 client,
                 commits,
                 self.app.repo.ignored_labels,
-                self.include_labels,
+                self.pr_labels,
             ):
                 shown_index = str(index + 1)
                 self.sidebar.label.update(f' {shown_index} / {total} ({ignored} ignored)')
@@ -269,10 +269,10 @@ class CandidateSidebar(LabeledBox):
         previous_ref: str,
         current_ref: str,
         labels: tuple[str, ...],
-        include_labels: list[str] | None = None,
+        pr_labels: list[str] | None = None,
     ):
         self.__status = StatusLabel()
-        self.__listing = CandidateListing(self, previous_ref, current_ref, labels, include_labels)
+        self.__listing = CandidateListing(self, previous_ref, current_ref, labels, pr_labels)
         self.__button = Button('Create', variant='primary', disabled=True, id='sidebar-button')
 
         super().__init__(
@@ -468,7 +468,7 @@ class CreateScreen(Screen):
         previous_ref: str,
         current_ref: str,
         labels: tuple[str, ...],
-        include_labels: list[str] | None = None,
+        pr_labels: list[str] | None = None,
         *args,
         **kwargs,
     ):
@@ -477,7 +477,7 @@ class CreateScreen(Screen):
         self.__previous_ref = previous_ref
         self.__current_ref = current_ref
         self.__labels = labels
-        self.__include__labels = include_labels
+        self.__include__labels = pr_labels
 
     @property
     def previous_ref(self) -> str:
@@ -492,14 +492,14 @@ class CreateScreen(Screen):
         return self.__labels
 
     @property
-    def include_labels(self) -> list[str] | None:
+    def pr_labels(self) -> list[str] | None:
         return self.__include__labels
 
     def compose(self) -> ComposeResult:
         yield Header()
         yield Container(
             Container(
-                CandidateSidebar(self.previous_ref, self.current_ref, self.labels, self.include_labels),
+                CandidateSidebar(self.previous_ref, self.current_ref, self.labels, self.pr_labels),
                 id='screen-create-sidebar',
             ),
             Container(CandidateRendering(), id='screen-create-rendering'),

--- a/src/ddqa/screens/create.py
+++ b/src/ddqa/screens/create.py
@@ -76,7 +76,14 @@ class CandidateListing(DataTable):
     """
 
     def __init__(
-        self, sidebar: CandidateSidebar, previous_ref: str, current_ref: str, labels: tuple[str, ...], *args, **kwargs
+        self,
+        sidebar: CandidateSidebar,
+        previous_ref: str,
+        current_ref: str,
+        labels: tuple[str, ...],
+        include_labels: list[str] | None = None,
+        *args,
+        **kwargs,
     ):
         super().__init__(*args, **kwargs)
 
@@ -84,6 +91,7 @@ class CandidateListing(DataTable):
         self.previous_ref = previous_ref
         self.current_ref = current_ref
         self.labels = labels
+        self.include_labels = include_labels
 
         self.candidates: dict[int, Candidate] = {}
 
@@ -119,7 +127,10 @@ class CandidateListing(DataTable):
 
         async with ResponsiveNetworkClient(self.sidebar.status) as client:
             async for model, index, ignored in self.app.github.get_candidates(
-                client, commits, self.app.repo.ignored_labels
+                client,
+                commits,
+                self.app.repo.ignored_labels,
+                self.include_labels,
             ):
                 shown_index = str(index + 1)
                 self.sidebar.label.update(f' {shown_index} / {total} ({ignored} ignored)')
@@ -253,9 +264,15 @@ class CandidateSidebar(LabeledBox):
     }
     """
 
-    def __init__(self, previous_ref: str, current_ref: str, labels: tuple[str, ...]):
+    def __init__(
+        self,
+        previous_ref: str,
+        current_ref: str,
+        labels: tuple[str, ...],
+        include_labels: list[str] | None = None,
+    ):
         self.__status = StatusLabel()
-        self.__listing = CandidateListing(self, previous_ref, current_ref, labels)
+        self.__listing = CandidateListing(self, previous_ref, current_ref, labels, include_labels)
         self.__button = Button('Create', variant='primary', disabled=True, id='sidebar-button')
 
         super().__init__(
@@ -446,12 +463,21 @@ class CreateScreen(Screen):
     }
     """
 
-    def __init__(self, previous_ref: str, current_ref: str, labels: tuple[str, ...], *args, **kwargs):
+    def __init__(
+        self,
+        previous_ref: str,
+        current_ref: str,
+        labels: tuple[str, ...],
+        include_labels: list[str] | None = None,
+        *args,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
 
         self.__previous_ref = previous_ref
         self.__current_ref = current_ref
         self.__labels = labels
+        self.__include__labels = include_labels
 
     @property
     def previous_ref(self) -> str:
@@ -465,10 +491,17 @@ class CreateScreen(Screen):
     def labels(self) -> tuple[str, ...]:
         return self.__labels
 
+    @property
+    def include_labels(self) -> list[str] | None:
+        return self.__include__labels
+
     def compose(self) -> ComposeResult:
         yield Header()
         yield Container(
-            Container(CandidateSidebar(self.previous_ref, self.current_ref, self.labels), id='screen-create-sidebar'),
+            Container(
+                CandidateSidebar(self.previous_ref, self.current_ref, self.labels, self.include_labels),
+                id='screen-create-sidebar',
+            ),
             Container(CandidateRendering(), id='screen-create-rendering'),
             id='screen-create',
         )

--- a/src/ddqa/utils/github.py
+++ b/src/ddqa/utils/github.py
@@ -140,7 +140,7 @@ class GitHubRepository:
         client: ResponsiveNetworkClient,
         commits: Iterable[GitCommit],
         ignored_labels: Iterable[str] | None = None,
-        include_labels: Iterable[str] | None = None,
+        pr_labels: Iterable[str] | None = None,
     ) -> AsyncIterator[tuple[TestCandidate | None, int, int]]:
         processed_pr_numbers = set()
         ignored = 0
@@ -155,7 +155,7 @@ class GitHubRepository:
                 processed_pr_numbers.add(model.id)
 
                 labels = {label.name for label in model.labels}
-                if (include_labels and not any(label in labels for label in include_labels)) or (
+                if (pr_labels and not any(label in labels for label in pr_labels)) or (
                     ignored_labels and any(label in labels for label in ignored_labels)
                 ):
                     ignored += 1

--- a/src/ddqa/utils/github.py
+++ b/src/ddqa/utils/github.py
@@ -140,6 +140,7 @@ class GitHubRepository:
         client: ResponsiveNetworkClient,
         commits: Iterable[GitCommit],
         ignored_labels: Iterable[str] | None = None,
+        include_labels: Iterable[str] | None = None,
     ) -> AsyncIterator[tuple[TestCandidate | None, int, int]]:
         processed_pr_numbers = set()
         ignored = 0
@@ -154,7 +155,9 @@ class GitHubRepository:
                 processed_pr_numbers.add(model.id)
 
                 labels = {label.name for label in model.labels}
-                if ignored_labels and any(label in labels for label in ignored_labels):
+                if (include_labels and not any(label in labels for label in include_labels)) or (
+                    ignored_labels and any(label in labels for label in ignored_labels)
+                ):
                     ignored += 1
                     yield None, index, ignored
                     continue

--- a/tests/cli/config/test_show.py
+++ b/tests/cli/config/test_show.py
@@ -13,7 +13,7 @@ def test_default_scrubbed(ddqa, config_file, helpers):
         """
         repo = ""
         cache_dir = ""
-        include_labels = []
+        pr_labels = []
 
         [github]
         user = "foo"
@@ -39,7 +39,7 @@ def test_reveal(ddqa, config_file, helpers):
         """
         repo = ""
         cache_dir = ""
-        include_labels = []
+        pr_labels = []
 
         [github]
         user = "foo"

--- a/tests/cli/config/test_show.py
+++ b/tests/cli/config/test_show.py
@@ -13,6 +13,7 @@ def test_default_scrubbed(ddqa, config_file, helpers):
         """
         repo = ""
         cache_dir = ""
+        include_labels = []
 
         [github]
         user = "foo"
@@ -38,6 +39,7 @@ def test_reveal(ddqa, config_file, helpers):
         """
         repo = ""
         cache_dir = ""
+        include_labels = []
 
         [github]
         user = "foo"

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -279,7 +279,7 @@ class TestCandidates:
 
         assert candidates == [(None, 0, 1)]
 
-    async def test_get_candidates_include_labels(self, app, git_repository, mocker):
+    async def test_get_candidates_pr_labels(self, app, git_repository, mocker):
         app.configure(
             git_repository,
             caching=True,


### PR DESCRIPTION
# Problem 

Right now we can exclude PRs that have specific labels in the `create`. We do not have an option to only show PRs that have a specific tag (for instance, a `team` tag).

# What does this PR do?

- Add a new parameter to the `create` command to add as many labels as we want
- Use these labels to filter the PRs
- Optionally, if the parameter is not passed, check the user config for the `pr_labels` option and use it.

# Show time

| Before | After |
|--------|-------|
| ![before](https://github.com/DataDog/ddqa/assets/1266346/31e193cc-85a9-4a38-a05b-6b5e52d272c2) | ![after](https://github.com/DataDog/ddqa/assets/1266346/0fececb0-8861-4dd6-b3c5-5c102fe74f49) |

# Additional notes

https://datadoghq.atlassian.net/browse/AITS-320