### PR TITLE
Add an `auto_mode` option to automatically create the QA cards

### DIFF
--- a/src/ddqa/app/core.py
+++ b/src/ddqa/app/core.py
@@ -28,7 +28,15 @@ class Application(App):
     TITLE = 'Datadog QA'
     CSS = CSS
 
-    def __init__(self, config_file: ConfigFile, cache_dir: str = '', color: bool | None = None, *args, **kwargs):
+    def __init__(
+        self,
+        config_file: ConfigFile,
+        cache_dir: str = '',
+        color: bool | None = None,
+        auto_mode: bool = False,  # noqa
+        *args,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
 
         self.__console = Console(
@@ -39,6 +47,7 @@ class Application(App):
             highlight=False,
         )
         self.config_file = config_file
+        self.auto_mode = auto_mode
         self.__cache_dir = cache_dir
         self.__queued_screens: list[tuple[str, Screen]] = []
 
@@ -124,7 +133,7 @@ class Application(App):
         elif not self.is_screen_installed('sync') and self.needs_syncing():
             from ddqa.screens.sync import SyncScreen
 
-            await self.push_screen(SyncScreen())
+            await self.push_screen(SyncScreen(auto_mode=self.auto_mode))
         else:
             for name, _ in self.__queued_screens:
                 await self.push_screen(name)

--- a/src/ddqa/cli/__init__.py
+++ b/src/ddqa/cli/__init__.py
@@ -32,8 +32,9 @@ from ddqa.config.constants import AppEnvVars, ConfigEnvVars
     help='The path to a custom config file to use [env var: `DDQA_CONFIG`]',
 )
 @click.version_option(version=__version__, prog_name='ddqa')
+@click.option('--auto', 'auto_mode', is_flag=True, help='Automatically runs the UI without any user interactions')
 @click.pass_context
-def ddqa(ctx: click.Context, color, cache_dir, config_file_path):
+def ddqa(ctx: click.Context, color, cache_dir, config_file_path, auto_mode):
     """
     \b
          _     _
@@ -69,7 +70,7 @@ def ddqa(ctx: click.Context, color, cache_dir, config_file_path):
                 )
                 ctx.exit(1)
 
-    app = Application(config_file, cache_dir, color)
+    app = Application(config_file, cache_dir, color, auto_mode)
 
     if not ctx.invoked_subcommand:
         click.echo(ctx.get_help())

--- a/src/ddqa/cli/create/__init__.py
+++ b/src/ddqa/cli/create/__init__.py
@@ -43,5 +43,5 @@ def create(
     if not pr_labels:
         pr_labels = app.config.app.pr_labels
 
-    app.select_screen('create', CreateScreen(previous_ref, current_ref, labels, pr_labels))
+    app.select_screen('create', CreateScreen(previous_ref, current_ref, labels, pr_labels, auto_mode=app.auto_mode))
     app.run()

--- a/src/ddqa/cli/sync/__init__.py
+++ b/src/ddqa/cli/sync/__init__.py
@@ -17,5 +17,5 @@ def sync(app: Application):
     """Sync team data."""
     from ddqa.screens.sync import SyncScreen
 
-    app.select_screen('sync', SyncScreen(manual_execution=True))
+    app.select_screen('sync', SyncScreen(manual_execution=True, auto_mode=app.auto_mode))
     app.run()

--- a/src/ddqa/screens/configure.py
+++ b/src/ddqa/screens/configure.py
@@ -197,7 +197,7 @@ class ConfigurationInput(Widget):
         if self.app.needs_syncing():
             from ddqa.screens.sync import SyncScreen
 
-            self.app.install_screen(SyncScreen(), 'sync')
+            self.app.install_screen(SyncScreen(auto_mode=self.app.auto_mode), 'sync')
             await self.app.switch_screen('sync')
         else:
             await self.app.switch_screen(list(self.app._installed_screens)[0])

--- a/src/ddqa/screens/create.py
+++ b/src/ddqa/screens/create.py
@@ -13,6 +13,7 @@ from textual.binding import Binding
 from textual.containers import Container, HorizontalScroll, VerticalScroll
 from textual.screen import Screen
 from textual.widgets import Button, DataTable, Header, Label, Markdown, Switch
+from textual.worker import Worker, WorkerState
 
 from ddqa.cache.github import GitHubCache
 from ddqa.models.jira import JiraConfig
@@ -82,6 +83,7 @@ class CandidateListing(DataTable):
         current_ref: str,
         labels: tuple[str, ...],
         pr_labels: list[str] | None = None,
+        auto_mode: bool = False,  # noqa
         *args,
         **kwargs,
     ):
@@ -92,6 +94,7 @@ class CandidateListing(DataTable):
         self.current_ref = current_ref
         self.labels = labels
         self.pr_labels = pr_labels
+        self.auto_mode = auto_mode
 
         self.candidates: dict[int, Candidate] = {}
 
@@ -151,6 +154,10 @@ class CandidateListing(DataTable):
 
         self.app.print('Finished processing candidates')
         self.sidebar.update_assignment_status()
+
+    async def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
+        if event.state not in (WorkerState.PENDING, WorkerState.RUNNING) and self.auto_mode:
+            await self.sidebar.create_cards_or_exit()
 
     async def create(self) -> None:
         candidates: dict[int, Candidate] = {}
@@ -232,6 +239,9 @@ class CandidateListing(DataTable):
         self.sidebar.status.update('Finished')
         self.sidebar.button.disabled = False
 
+        if self.sidebar.auto_mode:
+            self.app.exit()
+
 
 class StatusLabel(Label):
     def loading(self) -> None:
@@ -270,10 +280,13 @@ class CandidateSidebar(LabeledBox):
         current_ref: str,
         labels: tuple[str, ...],
         pr_labels: list[str] | None = None,
+        *,
+        auto_mode: bool = False,
     ):
         self.__status = StatusLabel()
-        self.__listing = CandidateListing(self, previous_ref, current_ref, labels, pr_labels)
+        self.__listing = CandidateListing(self, previous_ref, current_ref, labels, pr_labels, auto_mode=auto_mode)
         self.__button = Button('Create', variant='primary', disabled=True, id='sidebar-button')
+        self.__auto_mode = auto_mode
 
         super().__init__(
             '',
@@ -294,6 +307,10 @@ class CandidateSidebar(LabeledBox):
     def button(self) -> Button:
         return self.__button
 
+    @property
+    def auto_mode(self) -> bool:
+        return self.__auto_mode
+
     def update_assignment_status(self, *, override_is_loading_flag: bool = True) -> None:
         assigned = 0
 
@@ -310,6 +327,9 @@ class CandidateSidebar(LabeledBox):
         self.status.update('Ready for creation' if assigned else 'No candidates assigned')
 
     async def on_button_pressed(self, _event: Button.Pressed) -> None:
+        await self.create_cards_or_exit()
+
+    async def create_cards_or_exit(self) -> None:
         if str(self.button.label) == 'Create':
             self.button.disabled = True
             self.button.label = 'Exit'
@@ -319,6 +339,10 @@ class CandidateSidebar(LabeledBox):
 
             self.run_worker(self.listing.create())
         else:
+            self.app.exit()
+
+    async def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
+        if event.state not in (WorkerState.PENDING, WorkerState.RUNNING) and self.auto_mode:
             self.app.exit()
 
 
@@ -470,6 +494,7 @@ class CreateScreen(Screen):
         labels: tuple[str, ...],
         pr_labels: list[str] | None = None,
         *args,
+        auto_mode: bool = False,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -478,6 +503,7 @@ class CreateScreen(Screen):
         self.__current_ref = current_ref
         self.__labels = labels
         self.__include__labels = pr_labels
+        self.__auto_mode = auto_mode
 
     @property
     def previous_ref(self) -> str:
@@ -495,11 +521,17 @@ class CreateScreen(Screen):
     def pr_labels(self) -> list[str] | None:
         return self.__include__labels
 
+    @property
+    def auto_mode(self) -> bool:
+        return self.__auto_mode
+
     def compose(self) -> ComposeResult:
         yield Header()
         yield Container(
             Container(
-                CandidateSidebar(self.previous_ref, self.current_ref, self.labels, self.pr_labels),
+                CandidateSidebar(
+                    self.previous_ref, self.current_ref, self.labels, self.pr_labels, auto_mode=self.__auto_mode
+                ),
                 id='screen-create-sidebar',
             ),
             Container(CandidateRendering(), id='screen-create-rendering'),

--- a/src/ddqa/screens/sync.py
+++ b/src/ddqa/screens/sync.py
@@ -9,6 +9,7 @@ from textual.containers import Container
 from textual.screen import Screen
 from textual.widget import Widget
 from textual.widgets import Button, Header, Label, RichLog
+from textual.worker import Worker, WorkerState
 
 from ddqa.utils.network import ResponsiveNetworkClient
 from ddqa.widgets.static import Placeholder
@@ -32,10 +33,11 @@ class InteractiveSidebar(Widget):
     }
     """
 
-    def __init__(self, *args, manual_execution, **kwargs):
+    def __init__(self, *args, manual_execution: bool = False, auto_mode: bool = False, **kwargs):
         super().__init__(*args, **kwargs)
 
         self.__manual_execution = manual_execution
+        self.__auto_mode = auto_mode
 
     def compose(self) -> ComposeResult:
         yield Label()
@@ -120,7 +122,14 @@ class InteractiveSidebar(Widget):
 
             button.disabled = False
 
+    async def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
+        if event.state not in (WorkerState.PENDING, WorkerState.RUNNING) and self.__auto_mode:
+            await self.exit_screen()
+
     async def on_button_pressed(self, _event: Button.Pressed) -> None:
+        await self.exit_screen()
+
+    async def exit_screen(self) -> None:
         if self.__manual_execution:
             self.app.exit()
         else:
@@ -150,15 +159,19 @@ class SyncScreen(Screen):
     }
     """
 
-    def __init__(self, *args, manual_execution=False, **kwargs):
+    def __init__(self, *args, manual_execution=False, auto_mode: bool = False, **kwargs):
         super().__init__(*args, **kwargs)
 
         self.__manual_execution = manual_execution
+        self.__auto_mode = auto_mode
 
     def compose(self) -> ComposeResult:
         yield Header()
         yield Container(
-            Container(InteractiveSidebar(manual_execution=self.__manual_execution), id='screen-sync-sidebar'),
+            Container(
+                InteractiveSidebar(manual_execution=self.__manual_execution, auto_mode=self.__auto_mode),
+                id='screen-sync-sidebar',
+            ),
             Container(Placeholder(width_factor=2), id='screen-sync-placeholder'),
             id='screen-sync',
         )

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2023-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+
+
+def assert_return_code(app, auto_mode):
+    if auto_mode:
+        assert app.return_code == 0
+    else:
+        assert app.return_code is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,11 @@ def app(config_file):
 
 
 @pytest.fixture
+def auto_mode_app(config_file):
+    return TestApplication(config_file, os.environ[ConfigEnvVars.CACHE], auto_mode=True)
+
+
+@pytest.fixture
 def temp_dir(tmp_path) -> Path:
     path = Path(tmp_path, 'temp')
     path.mkdir()

--- a/tests/screens/test_create.py
+++ b/tests/screens/test_create.py
@@ -20,6 +20,7 @@ from ddqa.screens.create import (
     get_assignee,
 )
 from ddqa.utils.git import GitCommit
+from tests.common import assert_return_code
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -54,6 +55,14 @@ def mock_remote_url():
 def app(app):
     app.select_screen('create', CreateScreen('previous_ref', 'current_ref', ('qa-1.2.3', 'label-9000')))
     return app
+
+
+@pytest.fixture
+def auto_mode_app(auto_mode_app):
+    auto_mode_app.select_screen(
+        'create', CreateScreen('previous_ref', 'current_ref', ('qa-1.2.3', 'label-9000'), auto_mode=True)
+    )
+    return auto_mode_app
 
 
 @pytest.fixture
@@ -137,7 +146,15 @@ class TestDefaultState:
             assert str(assignments[0].label.render()) == 'foo'
             assert assignments[0].switch.value is False
 
-    async def test_no_candidates(self, app, git_repository, helpers):
+    @pytest.mark.parametrize(
+        'application,auto_mode',
+        [
+            pytest.param('app', False, id='manual'),
+            pytest.param('auto_mode_app', True, id='auto'),
+        ],
+    )
+    async def test_no_candidates(self, application, auto_mode, request, git_repository, helpers):
+        app = request.getfixturevalue(application)
         app.configure(
             git_repository,
             caching=True,
@@ -154,8 +171,8 @@ class TestDefaultState:
             assert sidebar is not None
             assert not sidebar.listing.rows
             assert str(sidebar.label.render()) == ' No candidates '
-            assert str(sidebar.status.render()) == 'previous_ref -> current_ref'
-            assert sidebar.button.disabled
+            assert str(sidebar.status.render()) == ('previous_ref -> current_ref' if not auto_mode else 'Finished')
+            assert sidebar.button.disabled != auto_mode
 
             rendering = app.query_one(CandidateRendering)
             assert rendering is not None
@@ -167,6 +184,8 @@ class TestDefaultState:
             assert len(assignments) == 1
             assert str(assignments[0].label.render()) == 'foo'
             assert assignments[0].switch.value is False
+
+        assert_return_code(app, auto_mode)
 
 
 async def test_population(app, git_repository, helpers, mock_pull_requests):
@@ -393,6 +412,91 @@ class TestAssignment:
             assert assignments[0].switch.value
             assert str(assignments[1].label.render()) == 'bar'
             assert not assignments[1].switch.value
+
+    async def test_auto_mode(self, auto_mode_app, git_repository, helpers, mock_pull_requests, mocker):
+        auto_mode_app.configure(
+            git_repository,
+            caching=True,
+            data={'github': {'user': 'foo', 'token': 'bar'}, 'jira': {'email': 'foo@bar.baz', 'token': 'bar'}},
+            github_teams={'foo-team': ['github-foo1']},
+        )
+        repo_config = dict(auto_mode_app.repo.model_dump())
+        repo_config['teams'] = {
+            'foo': {
+                'jira_project': 'FOO',
+                'jira_issue_type': 'Foo-Task',
+                'jira_statuses': {'TODO': 'Backlog', 'IN PROGRESS': 'Sprint', 'DONE': 'Done'},
+                'github_team': 'foo-team',
+                'github_labels': ['foo-label'],
+            },
+            'bar': {
+                'jira_project': 'BAR',
+                'jira_issue_type': 'Bar-Task',
+                'jira_statuses': {'TODO': 'Backlog', 'IN PROGRESS': 'Sprint', 'DONE': 'Done'},
+                'github_team': 'bar-team',
+                'github_labels': ['bar-label'],
+            },
+        }
+        auto_mode_app.save_repo_config(repo_config)
+
+        mock_pull_requests(
+            {
+                'number': '2',
+                'title': 'title2',
+                'user': {'login': 'username2'},
+                'labels': [{'name': 'foo-label', 'color': '632ca6'}, {'name': 'baz-label', 'color': '632ca6'}],
+                'body': 'foo2\r\nbar2',
+            },
+            {
+                'number': '2',
+                'title': 'title2',
+                'user': {'login': 'username2'},
+                'labels': [{'name': 'foo-label', 'color': '632ca6'}, {'name': 'baz-label', 'color': '632ca6'}],
+                'body': 'foo2\r\nbar2',
+            },
+            {},
+            {
+                'number': '1',
+                'title': 'title1',
+                'user': {'login': 'username1'},
+                'labels': [{'name': 'bar-label', 'color': '632ca6'}, {'name': 'baz-label', 'color': '632ca6'}],
+                'body': 'foo1\r\nbar1',
+            },
+        )
+
+        create_issues_mock = mocker.patch('ddqa.utils.jira.JiraClient.create_issues')
+
+        async with auto_mode_app.run_test() as pilot:
+            await pilot.pause(helpers.ASYNC_WAIT)
+
+            sidebar = auto_mode_app.query_one(CandidateSidebar)
+            table = sidebar.listing
+            num_candidates = len(table.rows)
+            assert num_candidates == 2
+            assert table.get_row_at(0) == ['✓', 'title2']
+            assert table.get_row_at(1) == ['', 'title1']
+            assert [c.assigned for c in table.candidates.values()] == [
+                True,
+                True,
+            ]
+
+            assert table.cursor_coordinate == Coordinate(0, 0)
+
+            assert str(sidebar.label.render()) == f' 2 / {num_candidates} '
+            assert str(sidebar.status.render()) == 'Ready for creation'
+            assert not sidebar.button.disabled
+
+            rendering = auto_mode_app.query_one(CandidateRendering)
+            assignments = list(rendering.candidate_assignments.query(LabeledSwitch).results())
+            assert len(assignments) == 2
+            assert str(assignments[0].label.render()) == 'foo'
+            assert assignments[0].switch.value
+            assert str(assignments[1].label.render()) == 'bar'
+            assert not assignments[1].switch.value
+
+            assert create_issues_mock.call_count == 1
+
+            assert auto_mode_app.return_code == 0
 
     async def test_default_with_cached_assignment(self, app, git_repository, helpers, mock_pull_requests):
         app.configure(

--- a/tests/screens/test_sync.py
+++ b/tests/screens/test_sync.py
@@ -9,6 +9,7 @@ from httpx import Request, Response
 from textual.widgets import Button, Label, RichLog
 
 from ddqa.screens.sync import InteractiveSidebar, SyncScreen
+from tests.common import assert_return_code
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -21,6 +22,12 @@ def mock_remote_url():
 def app(app):
     app.select_screen('sync', SyncScreen(manual_execution=True))
     return app
+
+
+@pytest.fixture
+def auto_mode_app(auto_mode_app):
+    auto_mode_app.select_screen('sync', SyncScreen(manual_execution=True, auto_mode=True))
+    return auto_mode_app
 
 
 async def test_response_error(app, git_repository, helpers, mocker):
@@ -73,7 +80,15 @@ async def test_parsing_error(app, git_repository, helpers, mocker):
         assert button.disabled
 
 
-async def test_no_members(app, git_repository, helpers, mocker):
+@pytest.mark.parametrize(
+    'application,auto_mode',
+    [
+        pytest.param('app', False, id='manual'),
+        pytest.param('auto_mode_app', True, id='auto'),
+    ],
+)
+async def test_no_members(application, auto_mode, request, git_repository, helpers, mocker):
+    app = request.getfixturevalue(application)
     app.configure(
         git_repository,
         caching=True,
@@ -97,8 +112,18 @@ async def test_no_members(app, git_repository, helpers, mocker):
         button = sidebar.query_one(Button)
         assert button.disabled
 
+    assert_return_code(app, auto_mode)
 
-async def test_save_members(app, git_repository, helpers, mocker):
+
+@pytest.mark.parametrize(
+    'application,auto_mode',
+    [
+        pytest.param('app', False, id='manual'),
+        pytest.param('auto_mode_app', True, id='auto'),
+    ],
+)
+async def test_save_members(application, auto_mode, request, git_repository, helpers, mocker):
+    app = request.getfixturevalue(application)
     app.configure(
         git_repository,
         caching=True,
@@ -139,11 +164,10 @@ async def test_save_members(app, git_repository, helpers, mocker):
     }
     app.save_repo_config(repo_config)
 
+    mocker.patch('ddqa.utils.github.GitHubRepository.get_team_members', side_effect=[])
+
     async with app.run_test():
         sidebar = app.query_one(InteractiveSidebar)
-
-        status = sidebar.query_one(Label)
-        assert '500' in str(status.render())
 
         text_log = sidebar.query_one(RichLog)
         assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
@@ -161,8 +185,18 @@ async def test_save_members(app, git_repository, helpers, mocker):
             'members': {'g': 'j'},
         }
 
+    assert_return_code(app, auto_mode)
 
-async def test_save_teams(app, git_repository, helpers, mocker):
+
+@pytest.mark.parametrize(
+    'application,auto_mode',
+    [
+        pytest.param('app', False, id='manual'),
+        pytest.param('auto_mode_app', True, id='auto'),
+    ],
+)
+async def test_save_teams(application, auto_mode, git_repository, helpers, mocker, request):
+    app = request.getfixturevalue(application)
     app.configure(
         git_repository,
         caching=True,
@@ -231,8 +265,18 @@ async def test_save_teams(app, git_repository, helpers, mocker):
             'members': {'g': 'j', 'bar1': 'jira-bar1', 'foo1': 'jira-foo1'},
         }
 
+        assert_return_code(app, auto_mode)
 
-async def test_deactivated_jira_user(app, git_repository, helpers, mocker):
+
+@pytest.mark.parametrize(
+    'application,auto_mode',
+    [
+        pytest.param('app', False, id='manual'),
+        pytest.param('auto_mode_app', True, id='auto'),
+    ],
+)
+async def test_deactivated_jira_user(application, auto_mode, git_repository, helpers, mocker, request):
+    app = request.getfixturevalue(application)
     app.configure(
         git_repository,
         caching=True,
@@ -301,8 +345,18 @@ async def test_deactivated_jira_user(app, git_repository, helpers, mocker):
             'members': {'bar1': 'jira-bar1', 'foo1': 'jira-foo1'},
         }
 
+    assert_return_code(app, auto_mode)
 
-async def test_github_user_not_in_jira(app, git_repository, helpers, mocker):
+
+@pytest.mark.parametrize(
+    'application,auto_mode',
+    [
+        pytest.param('app', False, id='manual'),
+        pytest.param('auto_mode_app', True, id='auto'),
+    ],
+)
+async def test_github_user_not_in_jira(application, auto_mode, git_repository, helpers, mocker, request):
+    app = request.getfixturevalue(application)
     app.configure(
         git_repository,
         caching=True,
@@ -368,3 +422,5 @@ async def test_github_user_not_in_jira(app, git_repository, helpers, mocker):
             'jira_server': 'https://foo.atlassian.net',
             'members': {'foo1': 'jira-foo1', 'g': 'j'},
         }
+
+        assert_return_code(app, auto_mode)


### PR DESCRIPTION
# Problem

- We mainly rely on labels on PR to pre-assign Jira cards, so the RM does not have to go through a long list of PRs manually.
- This process is now reliable enough to allow us to trigger the creation of the cards automatically without requiring the user to click on the various buttons in the UI.

Ultimately we want to be able to run this in the CI.

# What does this PR do?

- Add an `--auto` flag to to allow users to automatically trigger the various events to create the QA cards.
- This flag is used in several cases: 
  1. `ddqa --auto sync` will automatically close the window at the end of the process.
  2. `ddqa --auto create` will tirgger the cards creation automatically. If a `sync` is required, the window will be automatically closed once finished.

# What does NOT this PR do?

For now, `ddqa` does not talk a lot. We will need to add more logs to be able to have the info of which cards were created, if errors are found and stuff like that but that will be for a future PR because having more log is not only needed for this specific feature.

# Show time

## Sync screen only

| Before | After |
|--------|-------|
| ![sync_before mov](https://github.com/DataDog/ddqa/assets/1266346/974caa41-b400-46af-ba47-d2747c1344b3) | ![sync_after mov](https://github.com/DataDog/ddqa/assets/1266346/dcc0fedb-80e5-4982-a641-070f0edd4ab5) |

## Create screen with sync 

| Before | After |
|--------|-------|
| ![create_before mov](https://github.com/DataDog/ddqa/assets/1266346/d404b53f-e7c0-4cd5-a0e1-17d17f9988d7) | ![create_after mov](https://github.com/DataDog/ddqa/assets/1266346/5f8773dc-bf7a-4b89-b0d0-212009bb70ab) |

# Additional notes

- Relates to https://datadoghq.atlassian.net/browse/AITS-311