### PR TITLE
Add a `config set` command to update the config file

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add direct links to GitHub and Jira in the sync screen
 - Check GitHub users are declared in the Jira config file in the sync screen
 - Add a `pr_labels` option to only show PRs which have on of these labels in the create screen
+- Add a `config set` command to update the config file
 
 ## 0.4.0 - 2023-06-21
 

--- a/src/ddqa/app/core.py
+++ b/src/ddqa/app/core.py
@@ -46,10 +46,14 @@ class Application(App):
             emoji=False,
             highlight=False,
         )
-        self.config_file = config_file
         self.auto_mode = auto_mode
+        self.__config_file = config_file
         self.__cache_dir = cache_dir
         self.__queued_screens: list[tuple[str, Screen]] = []
+
+    @property
+    def config_file(self) -> ConfigFile:
+        return self.__config_file
 
     @property
     def config(self) -> Config:

--- a/src/ddqa/cli/config/__init__.py
+++ b/src/ddqa/cli/config/__init__.py
@@ -7,6 +7,7 @@ from ddqa.cli.config.edit import edit
 from ddqa.cli.config.explore import explore
 from ddqa.cli.config.find import find
 from ddqa.cli.config.restore import restore
+from ddqa.cli.config.set import set_value
 from ddqa.cli.config.show import show
 
 
@@ -19,4 +20,5 @@ config.add_command(edit)
 config.add_command(explore)
 config.add_command(find)
 config.add_command(restore)
+config.add_command(set_value)
 config.add_command(show)

--- a/src/ddqa/cli/config/set.py
+++ b/src/ddqa/cli/config/set.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2023-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from ddqa.app.core import Application
+
+
+@click.command('set', short_help='Assign values to config file entries')
+@click.argument('key')
+@click.argument('value', required=False)
+@click.pass_obj
+def set_value(app: Application, key: str, value: str):
+    if value is None:
+        from fnmatch import fnmatch
+
+        from ddqa.config.utils import SCRUBBED_GLOBS
+
+        scrubbing = any(fnmatch(key, glob) for glob in SCRUBBED_GLOBS)
+        value = click.prompt(f'Value for `{key}`', hide_input=scrubbing)
+
+    app.config_file.model.set_field(key, value)
+    app.config_file.save()

--- a/src/ddqa/config/core.py
+++ b/src/ddqa/config/core.py
@@ -76,6 +76,17 @@ class Config:
         data['repos'] = repos
         return ReposConfig(**data).repos
 
+    def set_field(self, key: str, value: str):
+        config = self.data
+        fields = key.split('.')
+
+        for f in fields[:-1]:
+            if f not in config:
+                config[f] = {}
+            config = config[f]
+
+        config[fields[-1]] = value
+
 
 class TypeResilientDict(dict):
     """A `dict` whose `get` method also returns the default value when the key is not

--- a/src/ddqa/config/utils.py
+++ b/src/ddqa/config/utils.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 SCRUBBED_VALUE = '*****'
+SCRUBBED_GLOBS = ('github.token', 'jira.token')
 
 
 def scrub_config(config: dict):

--- a/tests/cli/config/test_set.py
+++ b/tests/cli/config/test_set.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2023-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+def test(ddqa, helpers):
+    result = ddqa('config', 'set', 'github.user', 'new-user')
+
+    assert result.exit_code == 0, result.output
+    assert not result.output
+
+    result = ddqa('config', 'show')
+
+    assert result.exit_code == 0, result.output
+    assert result.output == helpers.dedent(
+        """
+        repo = ""
+        cache_dir = ""
+        pr_labels = []
+
+        [github]
+        user = "new-user"
+
+        [jira]
+        """,
+        terminal=True,
+    )

--- a/tests/config/__init__.py
+++ b/tests/config/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT

--- a/tests/config/test_core.py
+++ b/tests/config/test_core.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2023-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+import pytest
+
+from ddqa.config.core import Config
+
+
+@pytest.fixture
+def config():
+    return Config({'foo': 'bar', 'baz': {'key': 'value'}})
+
+
+@pytest.mark.parametrize(
+    'key, value, expected_dict',
+    [
+        pytest.param(
+            'new_key',
+            'new_value',
+            {'foo': 'bar', 'new_key': 'new_value', 'baz': {'key': 'value'}},
+            id='new key',
+        ),
+        pytest.param(
+            'foo',
+            'new_value',
+            {'foo': 'new_value', 'baz': {'key': 'value'}},
+            id='existing key',
+        ),
+        pytest.param(
+            'new.key',
+            'new_value',
+            {'foo': 'bar', 'baz': {'key': 'value'}, 'new': {'key': 'new_value'}},
+            id='new composed key',
+        ),
+        pytest.param(
+            'baz.key',
+            'new_value',
+            {
+                'foo': 'bar',
+                'baz': {'key': 'new_value'},
+            },
+            id='existing composed key',
+        ),
+    ],
+)
+def test_set_field(config, key, value, expected_dict):
+    config.set_field(key, value)
+    assert config.data == expected_dict


### PR DESCRIPTION
# Problem

- The configuration is stored in a file that we can edit with `ddqa config edit`
- The only way to modify this file is to do it manually or using the `configure` screen
- We can't do it from the CLI, to configure it in the CI for instance

# What does this PR do?

- Add a `ddqa config set <key> <value>` command to be able to modify config option directly from the CLI

# Additional notes

Related to https://datadoghq.atlassian.net/browse/AITS-322