### PR TITLE
Use the `html_url` attribute to build the URL for the author

### DIFF
--- a/src/ddqa/models/github.py
+++ b/src/ddqa/models/github.py
@@ -21,6 +21,7 @@ class TestCandidate(BaseModel):
     title: str
     url: str
     user: str = ''
+    user_url: str = ''
     body: str = ''
     labels: list[PullRequestLabel] = []
     reviewers: list[PullRequestReviewer] = []

--- a/src/ddqa/screens/create.py
+++ b/src/ddqa/screens/create.py
@@ -431,7 +431,7 @@ class CandidateRendering(LabeledBox):
         label = f' [link={data.url}]{data.short_display()}[/link] '
 
         if data.user:
-            label += f'by [link=https://github.com/{data.user}]{data.user}[/link] '
+            label += f'by [link={data.user_url}]{escape(data.user)}[/link] '
 
         self.label.update(label)
         self.title.update(RichMarkdown(data.title))

--- a/src/ddqa/utils/github.py
+++ b/src/ddqa/utils/github.py
@@ -110,6 +110,8 @@ class GitHubRepository:
         candidate_data['title'] = pr_data['title']
         candidate_data['url'] = f'https://github.com/{self.repo_id}/pull/{pr_data["number"]}'
         candidate_data['user'] = pr_data['user']['login']
+        candidate_data['user_url'] = pr_data['user']['html_url']
+
         candidate_data['labels'] = [{'name': label['name'], 'color': label['color']} for label in pr_data['labels']]
 
         if pr_data['body'] is not None:

--- a/tests/screens/test_create.py
+++ b/tests/screens/test_create.py
@@ -245,7 +245,8 @@ async def test_population(app, git_repository, helpers, mock_pull_requests):
         assert assignments[0].switch.value is False
 
 
-async def test_rendering(app, git_repository, helpers, mock_pull_requests):
+@pytest.mark.parametrize('login', ['username2', 'username2[bot]'])
+async def test_rendering(app, git_repository, helpers, mock_pull_requests, login):
     app.configure(
         git_repository,
         caching=True,
@@ -257,7 +258,7 @@ async def test_rendering(app, git_repository, helpers, mock_pull_requests):
         {
             'number': '2',
             'title': 'title2',
-            'user': {'login': 'username2', 'html_url': 'https://github.com/username2'},
+            'user': {'login': login, 'html_url': 'https://github.com/username2'},
             'labels': [{'name': 'label1', 'color': '632ca6'}, {'name': 'label2', 'color': '632ca6'}],
             'body': 'foo2\r\nbar2',
         },
@@ -287,7 +288,7 @@ async def test_rendering(app, git_repository, helpers, mock_pull_requests):
         rendering = app.query_one(CandidateRendering)
         rendered_label = rendering.label.render()
         rendered_label_text = str(rendered_label)
-        assert rendered_label_text == ' #2 by username2 '
+        assert rendered_label_text == f' #2 by {login} '
         assert len(rendered_label.spans) == 2
         rendered_label_span = rendered_label.spans[0]
         assert rendered_label_span.start == 1

--- a/tests/screens/test_create.py
+++ b/tests/screens/test_create.py
@@ -200,14 +200,14 @@ async def test_population(app, git_repository, helpers, mock_pull_requests):
         {
             'number': '2',
             'title': 'title2',
-            'user': {'login': 'username2'},
+            'user': {'login': 'username2', 'html_url': 'https://github.com/username2'},
             'labels': [{'name': 'label1', 'color': '632ca6'}, {'name': 'label2', 'color': '632ca6'}],
             'body': 'foo2\r\nbar2',
         },
         {
             'number': '2',
             'title': 'title2',
-            'user': {'login': 'username2'},
+            'user': {'login': 'username2', 'html_url': 'https://github.com/username2'},
             'labels': [{'name': 'label1', 'color': '632ca6'}, {'name': 'label2', 'color': '632ca6'}],
             'body': 'foo2\r\nbar2',
         },
@@ -215,7 +215,7 @@ async def test_population(app, git_repository, helpers, mock_pull_requests):
         {
             'number': '1',
             'title': 'title1',
-            'user': {'login': 'username1'},
+            'user': {'login': 'username1', 'html_url': 'https://github.com/username1'},
             'labels': [{'name': 'label1', 'color': '632ca6'}, {'name': 'label2', 'color': '632ca6'}],
             'body': 'foo1\r\nbar1',
         },
@@ -257,14 +257,14 @@ async def test_rendering(app, git_repository, helpers, mock_pull_requests):
         {
             'number': '2',
             'title': 'title2',
-            'user': {'login': 'username2'},
+            'user': {'login': 'username2', 'html_url': 'https://github.com/username2'},
             'labels': [{'name': 'label1', 'color': '632ca6'}, {'name': 'label2', 'color': '632ca6'}],
             'body': 'foo2\r\nbar2',
         },
         {
             'number': '2',
             'title': 'title2',
-            'user': {'login': 'username2'},
+            'user': {'login': 'username2', 'html_url': 'https://github.com/username2'},
             'labels': [{'name': 'label1', 'color': '632ca6'}, {'name': 'label2', 'color': '632ca6'}],
             'body': 'foo2\r\nbar2',
         },
@@ -272,7 +272,7 @@ async def test_rendering(app, git_repository, helpers, mock_pull_requests):
         {
             'number': '1',
             'title': 'title1',
-            'user': {'login': 'username1'},
+            'user': {'login': 'username1', 'html_url': 'https://github.com/username1'},
             'labels': [{'name': 'label1', 'color': '632ca6'}, {'name': 'label2', 'color': '632ca6'}],
             'body': 'foo1\r\nbar1',
         },
@@ -362,14 +362,14 @@ class TestAssignment:
             {
                 'number': '2',
                 'title': 'title2',
-                'user': {'login': 'username2'},
+                'user': {'login': 'username2', 'html_url': 'https://github.com/username2'},
                 'labels': [{'name': 'foo-label', 'color': '632ca6'}, {'name': 'baz-label', 'color': '632ca6'}],
                 'body': 'foo2\r\nbar2',
             },
             {
                 'number': '2',
                 'title': 'title2',
-                'user': {'login': 'username2'},
+                'user': {'login': 'username2', 'html_url': 'https://github.com/username2'},
                 'labels': [{'name': 'foo-label', 'color': '632ca6'}, {'name': 'baz-label', 'color': '632ca6'}],
                 'body': 'foo2\r\nbar2',
             },
@@ -377,7 +377,7 @@ class TestAssignment:
             {
                 'number': '1',
                 'title': 'title1',
-                'user': {'login': 'username1'},
+                'user': {'login': 'username1', 'html_url': 'https://github.com/username1'},
                 'labels': [{'name': 'bar-label', 'color': '632ca6'}, {'name': 'baz-label', 'color': '632ca6'}],
                 'body': 'foo1\r\nbar1',
             },
@@ -443,14 +443,14 @@ class TestAssignment:
             {
                 'number': '2',
                 'title': 'title2',
-                'user': {'login': 'username2'},
+                'user': {'login': 'username2', 'html_url': 'https://github.com/username2'},
                 'labels': [{'name': 'foo-label', 'color': '632ca6'}, {'name': 'baz-label', 'color': '632ca6'}],
                 'body': 'foo2\r\nbar2',
             },
             {
                 'number': '2',
                 'title': 'title2',
-                'user': {'login': 'username2'},
+                'user': {'login': 'username2', 'html_url': 'https://github.com/username2'},
                 'labels': [{'name': 'foo-label', 'color': '632ca6'}, {'name': 'baz-label', 'color': '632ca6'}],
                 'body': 'foo2\r\nbar2',
             },
@@ -458,7 +458,7 @@ class TestAssignment:
             {
                 'number': '1',
                 'title': 'title1',
-                'user': {'login': 'username1'},
+                'user': {'login': 'username1', 'html_url': 'https://github.com/username1'},
                 'labels': [{'name': 'bar-label', 'color': '632ca6'}, {'name': 'baz-label', 'color': '632ca6'}],
                 'body': 'foo1\r\nbar1',
             },
@@ -538,7 +538,7 @@ class TestAssignment:
             {
                 'number': '1',
                 'title': 'title1',
-                'user': {'login': 'username1'},
+                'user': {'login': 'username1', 'html_url': 'https://github.com/username1'},
                 'labels': [{'name': 'bar-label', 'color': '632ca6'}, {'name': 'baz-label', 'color': '632ca6'}],
                 'body': 'foo1\r\nbar1',
             },
@@ -597,14 +597,14 @@ class TestAssignment:
             {
                 'number': '2',
                 'title': 'title2',
-                'user': {'login': 'username2'},
+                'user': {'login': 'username2', 'html_url': 'https://github.com/username2'},
                 'labels': [{'name': 'foo-label', 'color': '632ca6'}, {'name': 'baz-label', 'color': '632ca6'}],
                 'body': 'foo2\r\nbar2',
             },
             {
                 'number': '2',
                 'title': 'title2',
-                'user': {'login': 'username2'},
+                'user': {'login': 'username2', 'html_url': 'https://github.com/username2'},
                 'labels': [{'name': 'foo-label', 'color': '632ca6'}, {'name': 'baz-label', 'color': '632ca6'}],
                 'body': 'foo2\r\nbar2',
             },
@@ -612,7 +612,7 @@ class TestAssignment:
             {
                 'number': '1',
                 'title': 'title1',
-                'user': {'login': 'username1'},
+                'user': {'login': 'username1', 'html_url': 'https://github.com/username1'},
                 'labels': [{'name': 'bar-label', 'color': '632ca6'}, {'name': 'baz-label', 'color': '632ca6'}],
                 'body': 'foo1\r\nbar1',
             },
@@ -720,14 +720,14 @@ class TestAssignment:
             {
                 'number': '2',
                 'title': 'title2',
-                'user': {'login': 'username2'},
+                'user': {'login': 'username2', 'html_url': 'https://github.com/username2'},
                 'labels': [{'name': 'foo-label', 'color': '632ca6'}, {'name': 'baz-label', 'color': '632ca6'}],
                 'body': 'foo2\r\nbar2',
             },
             {
                 'number': '2',
                 'title': 'title2',
-                'user': {'login': 'username2'},
+                'user': {'login': 'username2', 'html_url': 'https://github.com/username2'},
                 'labels': [{'name': 'foo-label', 'color': '632ca6'}, {'name': 'baz-label', 'color': '632ca6'}],
                 'body': 'foo2\r\nbar2',
             },
@@ -735,7 +735,7 @@ class TestAssignment:
             {
                 'number': '1',
                 'title': 'title1',
-                'user': {'login': 'username1'},
+                'user': {'login': 'username1', 'html_url': 'https://github.com/username1'},
                 'labels': [{'name': 'bar-label', 'color': '632ca6'}, {'name': 'bar-label', 'color': '632ca6'}],
                 'body': 'foo1\r\nbar1',
             },
@@ -804,7 +804,7 @@ class TestCreation:
             {
                 'number': '2',
                 'title': 'title2',
-                'user': {'login': 'github-foo1'},
+                'user': {'login': 'github-foo1', 'html_url': 'https://github.com/github-foo1'},
                 'labels': [{'name': 'foo-label', 'color': '632ca6'}],
                 'body': 'foo2\r\nbar2',
                 'reviewers': [
@@ -817,7 +817,7 @@ class TestCreation:
             {
                 'number': '2',
                 'title': 'title2',
-                'user': {'login': 'github-foo1'},
+                'user': {'login': 'github-foo1', 'html_url': 'https://github.com/github-foo1'},
                 'labels': [{'name': 'foo-label', 'color': '632ca6'}],
                 'body': 'foo2\r\nbar2',
                 'reviewers': [
@@ -831,7 +831,7 @@ class TestCreation:
             {
                 'number': '1',
                 'title': 'title1',
-                'user': {'login': 'github-bar1'},
+                'user': {'login': 'github-bar1', 'html_url': 'https://github.com/github-foo1'},
                 'labels': [{'name': 'foo-label', 'color': '632ca6'}, {'name': 'bar-label', 'color': '632ca6'}],
                 'body': 'foo1\r\nbar1',
                 'reviewers': [

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -55,7 +55,7 @@ class TestCandidates:
                                 {
                                     'number': '123',
                                     'title': 'title123',
-                                    'user': {'login': 'username123'},
+                                    'user': {'login': 'username123', 'html_url': 'https://github.com/username123'},
                                     'labels': [
                                         {'name': 'label1', 'color': '632ca6'},
                                         {'name': 'label2', 'color': '632ca6'},
@@ -72,15 +72,15 @@ class TestCandidates:
                     content=json.dumps(
                         [
                             {
-                                'user': {'login': 'username1'},
+                                'user': {'login': 'username1', 'html_url': 'https://github.com/username1'},
                                 'author_association': 'MEMBER',
                             },
                             {
-                                'user': {'login': 'username2'},
+                                'user': {'login': 'username2', 'html_url': 'https://github.com/username2'},
                                 'author_association': 'COLLABORATOR',
                             },
                             {
-                                'user': {'login': 'username1'},
+                                'user': {'login': 'username1', 'html_url': 'https://github.com/username1'},
                                 'author_association': 'MEMBER',
                             },
                         ],
@@ -106,6 +106,7 @@ class TestCandidates:
             'title': 'title123',
             'url': 'https://github.com/org/repo/pull/123',
             'user': 'username123',
+            'user_url': 'https://github.com/username123',
             'labels': [{'name': 'label1', 'color': '632ca6'}, {'name': 'label2', 'color': '632ca6'}],
             'body': 'foo\nbar',
             'reviewers': [
@@ -134,7 +135,7 @@ class TestCandidates:
                                 {
                                     'number': '123',
                                     'title': 'title123',
-                                    'user': {'login': 'username123'},
+                                    'user': {'login': 'username123', 'html_url': 'https://github.com/username123'},
                                     'labels': [
                                         {'name': 'label1', 'color': '632ca6'},
                                         {'name': 'label2', 'color': '632ca6'},
@@ -151,15 +152,15 @@ class TestCandidates:
                     content=json.dumps(
                         [
                             {
-                                'user': {'login': 'username1'},
+                                'user': {'login': 'username1', 'html_url': 'https://github.com/username1'},
                                 'author_association': 'MEMBER',
                             },
                             {
-                                'user': {'login': 'username2'},
+                                'user': {'login': 'username2', 'html_url': 'https://github.com/username2'},
                                 'author_association': 'COLLABORATOR',
                             },
                             {
-                                'user': {'login': 'username1'},
+                                'user': {'login': 'username1', 'html_url': 'https://github.com/username1'},
                                 'author_association': 'MEMBER',
                             },
                         ],
@@ -193,6 +194,7 @@ class TestCandidates:
                         'title': 'title123',
                         'url': 'https://github.com/org/repo/pull/123',
                         'user': 'username123',
+                        'user_url': 'https://github.com/username123',
                         'labels': [{'name': 'label1', 'color': '632ca6'}, {'name': 'label2', 'color': '632ca6'}],
                         'body': 'foo\nbar',
                         'reviewers': [
@@ -225,7 +227,7 @@ class TestCandidates:
                                 {
                                     'number': '123',
                                     'title': 'title123',
-                                    'user': {'login': 'username123'},
+                                    'user': {'login': 'username123', 'html_url': 'https://github.com/username123'},
                                     'labels': [
                                         {'name': 'label1', 'color': '632ca6'},
                                         {'name': 'label2', 'color': '632ca6'},
@@ -242,15 +244,15 @@ class TestCandidates:
                     content=json.dumps(
                         [
                             {
-                                'user': {'login': 'username1'},
+                                'user': {'login': 'username1', 'html_url': 'https://github.com/username1'},
                                 'author_association': 'MEMBER',
                             },
                             {
-                                'user': {'login': 'username2'},
+                                'user': {'login': 'username2', 'html_url': 'https://github.com/username2'},
                                 'author_association': 'COLLABORATOR',
                             },
                             {
-                                'user': {'login': 'username1'},
+                                'user': {'login': 'username1', 'html_url': 'https://github.com/username1'},
                                 'author_association': 'MEMBER',
                             },
                         ],
@@ -357,6 +359,7 @@ class TestCandidates:
             'title': 'subject9000',
             'url': 'https://github.com/org/repo/commit/hash9000',
             'user': '',
+            'user_url': '',
             'labels': [],
             'body': '',
             'reviewers': [],
@@ -445,6 +448,7 @@ class TestCandidates:
             'title': 'subject1',
             'url': 'https://github.com/org/repo/commit/hash1',
             'user': '',
+            'user_url': '',
             'labels': [],
             'body': '',
             'reviewers': [],
@@ -464,7 +468,7 @@ class TestCandidates:
                                 {
                                     'number': '123',
                                     'title': 'title123',
-                                    'user': {'login': 'username123'},
+                                    'user': {'login': 'username123', 'html_url': 'https://github.com/username123'},
                                     'labels': [
                                         {'name': 'label1', 'color': '632ca6'},
                                         {'name': 'label2', 'color': '632ca6'},
@@ -481,15 +485,15 @@ class TestCandidates:
                     content=json.dumps(
                         [
                             {
-                                'user': {'login': 'username1'},
+                                'user': {'login': 'username1', 'html_url': 'https://github.com/username1'},
                                 'author_association': 'MEMBER',
                             },
                             {
-                                'user': {'login': 'username2'},
+                                'user': {'login': 'username2', 'html_url': 'https://github.com/username2'},
                                 'author_association': 'COLLABORATOR',
                             },
                             {
-                                'user': {'login': 'username1'},
+                                'user': {'login': 'username1', 'html_url': 'https://github.com/username1'},
                                 'author_association': 'MEMBER',
                             },
                         ],
@@ -513,6 +517,7 @@ class TestCandidates:
             'title': 'title123',
             'url': 'https://github.com/org/repo/pull/123',
             'user': 'username123',
+            'user_url': 'https://github.com/username123',
             'labels': [{'name': 'label1', 'color': '632ca6'}, {'name': 'label2', 'color': '632ca6'}],
             'body': 'foo\nbar',
             'reviewers': [
@@ -547,6 +552,7 @@ class TestCandidates:
             'title': 'title123',
             'url': 'https://github.com/org/repo/pull/123',
             'user': 'username123',
+            'user_url': 'https://github.com/username123',
             'labels': [{'name': 'label1', 'color': '632ca6'}, {'name': 'label2', 'color': '632ca6'}],
             'body': 'foo\nbar',
             'reviewers': [
@@ -588,6 +594,7 @@ class TestCandidates:
             'title': 'title123',
             'url': 'https://github.com/org/repo/pull/123',
             'user': 'username123',
+            'user_url': 'https://github.com/username123',
             'labels': [{'name': 'label1', 'color': '632ca6'}, {'name': 'label2', 'color': '632ca6'}],
             'body': 'foo\nbar',
             'reviewers': [
@@ -607,6 +614,7 @@ class TestCandidates:
             'title': 'subject1',
             'url': 'https://github.com/org/repo/commit/hash1',
             'user': '',
+            'user_url': '',
             'labels': [],
             'body': '',
             'reviewers': [],
@@ -621,6 +629,7 @@ class TestCandidates:
             'title': 'title123',
             'url': 'https://github.com/org/repo/pull/123',
             'user': 'username123',
+            'user_url': 'https://github.com/username123',
             'labels': [{'name': 'label1', 'color': '632ca6'}, {'name': 'label2', 'color': '632ca6'}],
             'body': 'foo\nbar',
             'reviewers': [
@@ -638,6 +647,7 @@ class TestCandidates:
             'title': 'title123',
             'url': 'https://github.com/org/repo/pull/123',
             'user': 'username123',
+            'user_url': 'https://github.com/username123',
             'labels': [{'name': 'label1', 'color': '632ca6'}, {'name': 'label2', 'color': '632ca6'}],
             'body': 'foo\nbar',
             'reviewers': [
@@ -807,7 +817,7 @@ async def test_rate_limit_handling(app, git_repository, mocker):
                             {
                                 'number': '123',
                                 'title': 'title123',
-                                'user': {'login': 'username123'},
+                                'user': {'login': 'username123', 'html_url': 'https://github.com/username123'},
                                 'labels': [
                                     {'name': 'label1', 'color': '632ca6'},
                                     {'name': 'label2', 'color': '632ca6'},
@@ -828,15 +838,15 @@ async def test_rate_limit_handling(app, git_repository, mocker):
                 content=json.dumps(
                     [
                         {
-                            'user': {'login': 'username1'},
+                            'user': {'login': 'username1', 'html_url': 'https://github.com/username1'},
                             'author_association': 'MEMBER',
                         },
                         {
-                            'user': {'login': 'username2'},
+                            'user': {'login': 'username2', 'html_url': 'https://github.com/username2'},
                             'author_association': 'COLLABORATOR',
                         },
                         {
-                            'user': {'login': 'username1'},
+                            'user': {'login': 'username1', 'html_url': 'https://github.com/username1'},
                             'author_association': 'MEMBER',
                         },
                     ],
@@ -863,6 +873,7 @@ async def test_rate_limit_handling(app, git_repository, mocker):
         'title': 'title123',
         'url': 'https://github.com/org/repo/pull/123',
         'user': 'username123',
+        'user_url': 'https://github.com/username123',
         'labels': [{'name': 'label1', 'color': '632ca6'}, {'name': 'label2', 'color': '632ca6'}],
         'body': 'foo\nbar',
         'reviewers': [


### PR DESCRIPTION
# Problem

- When we try to create the cards for a PR that was opened by a GitHub app, the app crashes because we manually create the URL to its profile, it contains `[]`, which breaks the link.

![image](https://github.com/DataDog/ddqa/assets/1266346/8b15eadc-0732-478c-91c4-6d8fdaabab95)

# What does this PR do?

- Get the URL to the author profile using the `html_url` attribute, which works for both "real" users and GitHub Apps

# Additional notes



