### PR TITLE
Verify that no duplicated Jira users are found in the config

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Do not show PRs that have a ignored label in the create screen
 - Strip the PR title in the `create` screen
 - Stop assigning cards to users that are not declared in the Jira config
+- Verify that no duplicated Jira users are found in the config in the `sync` screen
 
 ***Added:***
 

--- a/src/ddqa/screens/sync.py
+++ b/src/ddqa/screens/sync.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 import tomllib
+from collections import Counter
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -99,6 +100,21 @@ class InteractiveSidebar(Widget):
                 except Exception as e:
                     status.update(str(e))
                     return
+
+            text_log.write('Validating the github-metadata configuration...', shrink=False)
+
+            members = global_config.get('members', {})
+            members_values_counter = Counter(members.values())
+
+            if duplicate_users := [key for key, value in members.items() if members_values_counter[value] > 1]:
+                for duplicate_user in duplicate_users:
+                    text_log.write(
+                        f'Jira user `{members[duplicate_user]}` is declared multiple times in the '
+                        f'[link={self.app.repo.global_config_source}]Jira config[/link] with GitHub '
+                        f'user `{duplicate_user}`',
+                        shrink=False,
+                    )
+                return
 
             text_log.write(f'Validating {len(global_config.get("members", {}))} Jira users...', shrink=False)
             try:

--- a/tests/screens/test_sync.py
+++ b/tests/screens/test_sync.py
@@ -253,6 +253,7 @@ async def test_save_teams(application, auto_mode, git_repository, helpers, mocke
             Fetching global config from: {app.repo.global_config_source}
             Refreshing members for team: bar-team
             Refreshing members for team: foo-team
+            Validating the github-metadata configuration...
             Validating 3 Jira users...
             """
         )
@@ -332,6 +333,7 @@ async def test_deactivated_jira_user(application, auto_mode, git_repository, hel
             Fetching global config from: {app.repo.global_config_source}
             Refreshing members for team: bar-team
             Refreshing members for team: foo-team
+            Validating the github-metadata configuration...
             Validating 3 Jira users...
             User g is deactivated on Jira
             """
@@ -411,6 +413,7 @@ async def test_github_user_not_in_jira(application, auto_mode, git_repository, h
             Refreshing members for team: bar-team
             Refreshing members for team: foo-team
             GitHub user bar1 is not declared in the Jira config
+            Validating the github-metadata configuration...
             Validating 2 Jira users...
             """
         )
@@ -424,3 +427,85 @@ async def test_github_user_not_in_jira(application, auto_mode, git_repository, h
         }
 
         assert_return_code(app, auto_mode)
+
+
+@pytest.mark.parametrize(
+    'application,auto_mode',
+    [
+        pytest.param('app', False, id='manual'),
+        pytest.param('auto_mode_app', True, id='auto'),
+    ],
+)
+async def test_duplicate_jira_user(application, auto_mode, git_repository, helpers, mocker, request):
+    app = request.getfixturevalue(application)
+    app.configure(
+        git_repository,
+        caching=True,
+        data={'github': {'user': 'foo', 'token': 'bar'}, 'jira': {'email': 'foo@bar.baz', 'token': 'bar'}},
+    )
+    mocker.patch(
+        'httpx.AsyncClient.get',
+        side_effect=[
+            Response(
+                200,
+                request=Request('GET', ''),
+                content=helpers.dedent(
+                    """
+                    jira_server = "https://foo.atlassian.net"
+
+                    [members]
+                    g = "j"
+                    foo1 = "jira-foo1"
+                    bar1 = "jira-foo1"
+                    baz1 = "jira-baz1"
+                    """
+                ),
+            ),
+        ],
+    )
+
+    mocker.patch('ddqa.utils.github.GitHubRepository.get_team_members', side_effect=(['foo1'], ['bar1']))
+    mock = MagicMock()
+    mock.__aiter__.return_value = [{'accountId': 'j'}]
+    mocker.patch('ddqa.utils.jira.JiraClient.get_deactivated_users', return_value=mock)
+    repo_config = dict(app.repo.model_dump())
+    repo_config['teams'] = {
+        'foo': {
+            'jira_project': 'FOO',
+            'jira_issue_type': 'Foo-Task',
+            'jira_statuses': {'TODO': 'Backlog', 'IN PROGRESS': 'Sprint', 'DONE': 'Done'},
+            'github_team': 'foo-team',
+        },
+        'bar': {
+            'jira_project': 'BAR',
+            'jira_issue_type': 'Bar-Task',
+            'jira_statuses': {'TODO': 'Backlog', 'IN PROGRESS': 'Sprint', 'DONE': 'Done'},
+            'github_team': 'bar-team',
+        },
+    }
+    app.save_repo_config(repo_config)
+
+    async with app.run_test():
+        sidebar = app.query_one(InteractiveSidebar)
+        text_log = sidebar.query_one(RichLog)
+
+        assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
+            f"""
+            Fetching global config from: {app.repo.global_config_source}
+            Refreshing members for team: bar-team
+            Refreshing members for team: foo-team
+            Validating the github-metadata configuration...
+            Jira user `jira-foo1` is declared multiple times in the Jira config with GitHub user `foo1`
+            Jira user `jira-foo1` is declared multiple times in the Jira config with GitHub user `bar1`
+            """
+        )
+
+        button = sidebar.query_one(Button)
+        assert button.disabled
+
+        assert app.github.load_global_config(app.repo.global_config_source) == {
+            'jira_server': 'https://foo.atlassian.net',
+            'members': {'bar1': 'jira-foo1', 'foo1': 'jira-foo1', 'baz1': 'jira-baz1', 'g': 'j'},
+        }
+
+    assert_return_code(app, auto_mode)


### PR DESCRIPTION
# Context

`ddqa` relies on a mapping between github users <-> jira users. In our case, this mapping is stored in https://github.com/DataDog/github-metadata/blob/master/jira.toml

# Problem

A recent PR opened in the `github-metadata` repository added a new GitHub user linked to an already existing Jira user. Namely [here](https://github.com/DataDog/github-metadata/pull/28), `Kyle-Neale` was added but with `steven91`'s Jira user. 

This duplicate produces an error later on when we call the Jira API because we request two times the same user in the same request. 

# What does this PR do?

This PR adds a new validation before we start calling the Jira API to make sure we do not have duplicate Jira users. If there's a duplicate, it will be printed and we will stop the execution because we can't decide which one is the right one.

# Next steps

We should have a validation in `github-metadata` to avoid this problem and make the CI fails on PRs that adds a duplicate.