### PR TITLE
fix(github api): Update the search/issue API

### DIFF
--- a/src/ddqa/utils/github.py
+++ b/src/ddqa/utils/github.py
@@ -87,7 +87,11 @@ class GitHubRepository:
             client,
             self.ISSUE_SEARCH_API,
             # https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests
-            params={'q': f'sha:{commit.hash} repo:{self.repo_id} is:merged'},
+            # https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more/
+            params={
+                'q': f'sha:{commit.hash} AND repo:{self.repo_id} AND is:merged AND is:pull-request',
+                'advanced_search': True,
+            },
         )
         pr_data = response.json()
 

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -95,8 +95,11 @@ class TestCandidates:
         assert response_mock.call_args_list == [
             mocker.call(
                 'https://api.github.com/search/issues',
-                params={'q': 'sha:hash9000 repo:org/repo is:merged'},
                 auth=('foo', 'bar'),
+                params={
+                    'q': 'sha:hash9000 AND repo:org/repo AND is:merged AND is:pull-request',
+                    'advanced_search': True,
+                },
             ),
             mocker.call('https://api.github.com/repos/org/repo/pulls/123/reviews', auth=('foo', 'bar')),
         ]
@@ -179,8 +182,11 @@ class TestCandidates:
         assert response_mock.call_args_list == [
             mocker.call(
                 'https://api.github.com/search/issues',
-                params={'q': 'sha:hash9000 repo:org/repo is:merged'},
                 auth=('foo', 'bar'),
+                params={
+                    'q': 'sha:hash9000 AND repo:org/repo AND is:merged AND is:pull-request',
+                    'advanced_search': True,
+                },
             ),
             mocker.call('https://api.github.com/repos/org/repo/pulls/123/reviews', auth=('foo', 'bar')),
         ]
@@ -273,8 +279,11 @@ class TestCandidates:
         assert response_mock.call_args_list == [
             mocker.call(
                 'https://api.github.com/search/issues',
-                params={'q': 'sha:hash9000 repo:org/repo is:merged'},
                 auth=('foo', 'bar'),
+                params={
+                    'q': 'sha:hash9000 AND repo:org/repo AND is:merged AND is:pull-request',
+                    'advanced_search': True,
+                },
             ),
             mocker.call('https://api.github.com/repos/org/repo/pulls/123/reviews', auth=('foo', 'bar')),
         ]
@@ -349,8 +358,11 @@ class TestCandidates:
         assert response_mock.call_args_list == [
             mocker.call(
                 'https://api.github.com/search/issues',
-                params={'q': 'sha:hash9000 repo:org/repo is:merged'},
                 auth=('foo', 'bar'),
+                params={
+                    'q': 'sha:hash9000 AND repo:org/repo AND is:merged AND is:pull-request',
+                    'advanced_search': True,
+                },
             ),
         ]
 
@@ -392,8 +404,11 @@ class TestCandidates:
         assert response_mock.call_args_list == [
             mocker.call(
                 'https://api.github.com/search/issues',
-                params={'q': 'sha:hash9000 repo:org/repo is:merged'},
                 auth=('foo', 'bar'),
+                params={
+                    'q': 'sha:hash9000 AND repo:org/repo AND is:merged AND is:pull-request',
+                    'advanced_search': True,
+                },
             ),
         ]
 
@@ -439,8 +454,8 @@ class TestCandidates:
         assert response_mock.call_args_list == [
             mocker.call(
                 'https://api.github.com/search/issues',
-                params={'q': 'sha:hash1 repo:org/repo is:merged'},
                 auth=('foo', 'bar'),
+                params={'q': 'sha:hash1 AND repo:org/repo AND is:merged AND is:pull-request', 'advanced_search': True},
             ),
         ]
         assert candidate.model_dump() == {
@@ -507,8 +522,8 @@ class TestCandidates:
         assert response_mock.call_args_list == [
             mocker.call(
                 'https://api.github.com/search/issues',
-                params={'q': 'sha:hash2 repo:org/repo is:merged'},
                 auth=('foo', 'bar'),
+                params={'q': 'sha:hash2 AND repo:org/repo AND is:merged AND is:pull-request', 'advanced_search': True},
             ),
             mocker.call('https://api.github.com/repos/org/repo/pulls/123/reviews', auth=('foo', 'bar')),
         ]
@@ -543,8 +558,8 @@ class TestCandidates:
         assert response_mock.call_args_list == [
             mocker.call(
                 'https://api.github.com/search/issues',
-                params={'q': 'sha:hash3 repo:org/repo is:merged'},
                 auth=('foo', 'bar'),
+                params={'q': 'sha:hash3 AND repo:org/repo AND is:merged AND is:pull-request', 'advanced_search': True},
             ),
         ]
         assert candidate.model_dump() == {
@@ -862,8 +877,8 @@ async def test_rate_limit_handling(app, git_repository, mocker):
     assert response_mock.call_args_list == [
         mocker.call(
             'https://api.github.com/search/issues',
-            params={'q': 'sha:hash9000 repo:org/repo is:merged'},
             auth=('foo', 'bar'),
+            params={'q': 'sha:hash9000 AND repo:org/repo AND is:merged AND is:pull-request', 'advanced_search': True},
         ),
         mocker.call('https://api.github.com/repos/org/repo/pulls/123/reviews', auth=('foo', 'bar')),
         mocker.call('https://api.github.com/repos/org/repo/pulls/123/reviews', auth=('foo', 'bar')),


### PR DESCRIPTION
Update the search/issue API:
- add the `is:pull-request` field in the query. It prevents running into
```
{'message': "Query must include 'is:issue' or 'is:pull-request'", 'documentation_url': 'https://docs.github.com/rest/search/search#search-issues-and-pull-requests', 'status': '422'}
```
when calling the API with a fined-grained token
- use the [advanced_search param](https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more/). I just bumped into this so I decided to anticipate the migration.