### PR TITLE
Update github action to upload to pypi to 1.12.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -468,7 +468,7 @@ jobs:
         merge-multiple: true
 
     - name: Push Python artifacts to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.10.0
+      uses: pypa/gh-action-pypi-publish@v1.12.4
       with:
         skip-existing: true
         user: __token__


### PR DESCRIPTION
## Description
This PR updates the version of the cation used to pushed pypi packagds to v1.12.4.

The current one does not support v2.4 of the metadata spec, which is the one being used, and suppor for this version was added after [v1.12.3](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.12.3) of the action.