### PR TITLE
feat(create): Assign QA cards to PR author's team instead of all label-matched teams

### DIFF
--- a/docs/actions/create.md
+++ b/docs/actions/create.md
@@ -65,7 +65,7 @@ This section displays detailed information about the candidate, using the PR bod
 
 ### Pending assignments
 
-This section displays a toggle for each team determining whether they should be assigned to the candidate. The default state of each team's toggle will be enabled if any of the candidate's PR labels match the team's [defined labels](../config/repo.md#github-labels).
+This section displays a toggle for each team determining whether they should be assigned to the candidate. By default, if the PR author belongs to a configured GitHub team, only that team's toggle will be enabled. When the author is not a member of any configured team, the default state falls back to label matching: each team's toggle will be enabled if any of the candidate's PR labels match the team's [defined labels](../config/repo.md#github-labels).
 
 <figure markdown>
   ![Creation screen candidate assignments](../assets/images/creation-screen-candidate-assignments.png){ loading=lazy role="img" }

--- a/docs/config/repo.md
+++ b/docs/config/repo.md
@@ -97,7 +97,7 @@ This is an array of Jira statuses that correspond to the order of [QA status](#q
 
 Key: `github_labels`
 
-This team will be assigned by default to any pull requests that are labeled with any of the entries (as long as the pull request has no labels that match any of those defined as [ignored](#ignored-labels)).
+When a pull request author belongs to a configured [GitHub team](#github-team), only that team will be assigned by default. When the author is not a member of any configured team, this team will be assigned by default to any pull requests that are labeled with any of the entries (as long as the pull request has no labels that match any of those defined as [ignored](#ignored-labels)).
 
 ### Jira component
 

--- a/src/ddqa/screens/create.py
+++ b/src/ddqa/screens/create.py
@@ -142,9 +142,7 @@ class CandidateListing(DataTable):
                     self.app.print(f'Processing {model.long_display()}')
 
                     if model.user and not model.assigned_teams:
-                        author_team = await self.app.github.get_author_team(
-                            client, model.user, self.app.repo.teams
-                        )
+                        author_team = await self.app.github.get_author_team(client, model.user, self.app.repo.teams)
                         if author_team:
                             model.assigned_teams = {author_team}
 

--- a/src/ddqa/screens/create.py
+++ b/src/ddqa/screens/create.py
@@ -39,8 +39,8 @@ class Candidate:
         self.assignments: dict[str, bool] = {}
 
         for team_name, team_data in repo_config.teams.items():
-            if candidate.assigned_teams and team_name in candidate.assigned_teams:
-                assigned = True
+            if candidate.assigned_teams:
+                assigned = team_name in candidate.assigned_teams
             elif ignored:
                 assigned = False
             else:
@@ -140,6 +140,13 @@ class CandidateListing(DataTable):
 
                 if model is not None:
                     self.app.print(f'Processing {model.long_display()}')
+
+                    if model.user and not model.assigned_teams:
+                        author_team = await self.app.github.get_author_team(
+                            client, model.user, self.app.repo.teams
+                        )
+                        if author_team:
+                            model.assigned_teams = {author_team}
 
                     candidate = Candidate(model, self.app.repo, self.app.github.cache)
                     self.candidates[num_candidates] = candidate

--- a/src/ddqa/utils/github.py
+++ b/src/ddqa/utils/github.py
@@ -15,6 +15,7 @@ from ddqa.utils.fs import Path
 
 if TYPE_CHECKING:
     from ddqa.models.config.auth import GitHubAuth
+    from ddqa.models.config.team import TeamConfig
     from ddqa.models.github import TestCandidate
     from ddqa.utils.git import GitCommit, GitRepository
     from ddqa.utils.network import ResponsiveNetworkClient
@@ -78,6 +79,15 @@ class GitHubRepository:
             self.cache.save_team_members(team, members)
 
         return members
+
+    async def get_author_team(
+        self, client: ResponsiveNetworkClient, user: str, teams: dict[str, TeamConfig]
+    ) -> str | None:
+        for team_name, team_config in teams.items():
+            members = await self.get_team_members(client, team_config.github_team)
+            if user in members:
+                return team_name
+        return None
 
     async def get_candidate(self, client: ResponsiveNetworkClient, commit: GitCommit) -> TestCandidate:
         from ddqa.models.github import TestCandidate

--- a/tests/cli/config/test_restore.py
+++ b/tests/cli/config/test_restore.py
@@ -20,13 +20,9 @@ def test_standard(ddqa, config_file, helpers):
 
 
 def test_allow_invalid_config(ddqa, config_file, helpers):
-    config_file.save(
-        helpers.dedent(
-            """
+    config_file.save(helpers.dedent("""
             repo = [""]
-            """
-        )
-    )
+            """))
 
     result = ddqa('config', 'restore')
 

--- a/tests/screens/test_configure.py
+++ b/tests/screens/test_configure.py
@@ -32,8 +32,7 @@ async def test_default_state(app, helpers):
         assert save_button.disabled is True
 
         text_log = app.query_one(RichLog)
-        assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-            """
+        assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent("""
             Configuration errors
             ├── repo
             │     Field required
@@ -45,8 +44,7 @@ async def test_default_state(app, helpers):
             │     Field required
             └── jira -> token
                   Field required
-            """
-        )
+            """)
 
 
 class TestRepoNameInput:
@@ -68,13 +66,11 @@ class TestRepoNameInput:
             assert not app.config.data['repo']
             assert not input_box.value
             assert save_button.disabled is True
-            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-                """
+            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent("""
                 Configuration errors
                 └── repo
                       Field required
-                """
-            )
+                """)
 
     async def test_wrong_type(self, app, config_file, helpers):
         config_file.model.data.update(
@@ -94,13 +90,11 @@ class TestRepoNameInput:
             assert app.config.data['repo'] == ['foo']
             assert not input_box.value
             assert save_button.disabled is True
-            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-                """
+            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent("""
                 Configuration errors
                 └── repo
                       Input should be a valid string
-                """
-            )
+                """)
 
     async def test_unknown(self, app, config_file, helpers):
         config_file.model.data.update(
@@ -120,13 +114,11 @@ class TestRepoNameInput:
             assert app.config.data['repo'] == 'foo'
             assert input_box.value == 'foo'
             assert save_button.disabled is True
-            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-                """
+            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent("""
                 Configuration errors
                 └── repo
                       unknown repository: foo
-                """
-            )
+                """)
 
     async def test_save(self, app, isolation, config_file, helpers):
         config_file.model.data.update(
@@ -145,13 +137,11 @@ class TestRepoNameInput:
 
             assert not app.config.data['repo']
             assert not input_box.value
-            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-                """
+            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent("""
                 Configuration errors
                 └── repo
                       Field required
-                """
-            )
+                """)
             assert save_button.disabled is True
 
             app.set_focus(input_box)
@@ -183,13 +173,11 @@ class TestRepoPathInput:
             assert app.config.data['repos'] == {'agent': {}}
             assert not input_box.value
             assert save_button.disabled is True
-            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-                """
+            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent("""
                 Configuration errors
                 └── repos -> agent -> path
                       Field required
-                """
-            )
+                """)
 
     async def test_wrong_type(self, app, config_file, helpers):
         config_file.model.data.update(
@@ -210,13 +198,11 @@ class TestRepoPathInput:
             assert app.config.data['repos'] == {'agent': {'path': ['foo']}}
             assert not input_box.value
             assert save_button.disabled is True
-            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-                """
+            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent("""
                 Configuration errors
                 └── repos -> agent -> path
                       Input should be a valid string
-                """
-            )
+                """)
 
     async def test_does_not_exist(self, app, isolation, config_file, helpers):
         path = str(isolation / 'foo')
@@ -238,13 +224,11 @@ class TestRepoPathInput:
             assert app.config.data['repos'] == {'agent': {'path': path}}
             assert input_box.value == path
             assert save_button.disabled is True
-            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-                f"""
+            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(f"""
                 Configuration errors
                 └── repos -> agent -> path
                       Directory does not exist: {path}
-                """
-            )
+                """)
 
     async def test_save(self, app, isolation, config_file, helpers):
         path = str(isolation)
@@ -266,13 +250,11 @@ class TestRepoPathInput:
             assert app.config.data['repos'] == {'agent': {}}
             assert not input_box.value
             assert save_button.disabled is True
-            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-                """
+            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent("""
                 Configuration errors
                 └── repos -> agent -> path
                       Field required
-                """
-            )
+                """)
 
             app.set_focus(input_box)
             await pilot.pause(helpers.ASYNC_WAIT)
@@ -304,13 +286,11 @@ class TestGitHubUserInput:
             assert app.config.data['github'] == {'token': 'bar'}
             assert not input_box.value
             assert save_button.disabled is True
-            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-                """
+            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent("""
                 Configuration errors
                 └── github -> user
                       Field required
-                """
-            )
+                """)
 
     async def test_wrong_type(self, app, isolation, config_file, helpers):
         config_file.model.data.update(
@@ -331,13 +311,11 @@ class TestGitHubUserInput:
             assert app.config.data['github'] == {'user': ['foo'], 'token': 'bar'}
             assert not input_box.value
             assert save_button.disabled is True
-            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-                """
+            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent("""
                 Configuration errors
                 └── github -> user
                       Input should be a valid string
-                """
-            )
+                """)
 
     async def test_save(self, app, isolation, config_file, helpers):
         config_file.model.data.update(
@@ -358,13 +336,11 @@ class TestGitHubUserInput:
             assert app.config.data['github'] == {'token': 'bar'}
             assert not input_box.value
             assert save_button.disabled is True
-            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-                """
+            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent("""
                 Configuration errors
                 └── github -> user
                       Field required
-                """
-            )
+                """)
 
             app.set_focus(input_box)
             await pilot.press(*'foo')
@@ -396,13 +372,11 @@ class TestGitHubTokenInput:
             assert input_box.password is True
             assert not input_box.value
             assert save_button.disabled is True
-            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-                """
+            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent("""
                 Configuration errors
                 └── github -> token
                       Field required
-                """
-            )
+                """)
 
     async def test_wrong_type(self, app, isolation, config_file, helpers):
         config_file.model.data.update(
@@ -424,13 +398,11 @@ class TestGitHubTokenInput:
             assert input_box.password is True
             assert not input_box.value
             assert save_button.disabled is True
-            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-                """
+            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent("""
                 Configuration errors
                 └── github -> token
                       Input should be a valid string
-                """
-            )
+                """)
 
     async def test_save(self, app, isolation, config_file, helpers):
         config_file.model.data.update(
@@ -452,13 +424,11 @@ class TestGitHubTokenInput:
             assert input_box.password is True
             assert not input_box.value
             assert save_button.disabled is True
-            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-                """
+            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent("""
                 Configuration errors
                 └── github -> token
                       Field required
-                """
-            )
+                """)
 
             app.set_focus(input_box)
             await pilot.press(*'bar')
@@ -490,13 +460,11 @@ class TestJiraEmailInput:
             assert app.config.data['jira'] == {'token': 'bar'}
             assert not input_box.value
             assert save_button.disabled is True
-            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-                """
+            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent("""
                 Configuration errors
                 └── jira -> email
                       Field required
-                """
-            )
+                """)
 
     async def test_wrong_type(self, app, isolation, config_file, helpers):
         config_file.model.data.update(
@@ -517,13 +485,11 @@ class TestJiraEmailInput:
             assert app.config.data['jira'] == {'email': ['foo'], 'token': 'bar'}
             assert not input_box.value
             assert save_button.disabled is True
-            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-                """
+            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent("""
                 Configuration errors
                 └── jira -> email
                       Input should be a valid string
-                """
-            )
+                """)
 
     async def test_save(self, app, isolation, config_file, helpers):
         config_file.model.data.update(
@@ -544,13 +510,11 @@ class TestJiraEmailInput:
             assert app.config.data['jira'] == {'token': 'bar'}
             assert not input_box.value
             assert save_button.disabled is True
-            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-                """
+            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent("""
                 Configuration errors
                 └── jira -> email
                       Field required
-                """
-            )
+                """)
 
             app.set_focus(input_box)
             await pilot.press(*'foo')
@@ -582,13 +546,11 @@ class TestJiraTokenInput:
             assert input_box.password is True
             assert not input_box.value
             assert save_button.disabled is True
-            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-                """
+            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent("""
                 Configuration errors
                 └── jira -> token
                       Field required
-                """
-            )
+                """)
 
     async def test_wrong_type(self, app, isolation, config_file, helpers):
         config_file.model.data.update(
@@ -610,13 +572,11 @@ class TestJiraTokenInput:
             assert input_box.password is True
             assert not input_box.value
             assert save_button.disabled is True
-            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-                """
+            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent("""
                 Configuration errors
                 └── jira -> token
                       Input should be a valid string
-                """
-            )
+                """)
 
     async def test_save(self, app, isolation, config_file, helpers):
         config_file.model.data.update(
@@ -638,13 +598,11 @@ class TestJiraTokenInput:
             assert input_box.password is True
             assert not input_box.value
             assert save_button.disabled is True
-            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-                """
+            assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent("""
                 Configuration errors
                 └── jira -> token
                       Field required
-                """
-            )
+                """)
 
             app.set_focus(input_box)
             await pilot.press(*'bar')

--- a/tests/screens/test_create.py
+++ b/tests/screens/test_create.py
@@ -338,7 +338,7 @@ class TestAssignment:
             git_repository,
             caching=True,
             data={'github': {'user': 'foo', 'token': 'bar'}, 'jira': {'email': 'foo@bar.baz', 'token': 'bar'}},
-            github_teams={'foo-team': ['github-foo1']},
+            github_teams={'foo-team': ['github-foo1'], 'bar-team': ['github-bar1']},
         )
         repo_config = dict(app.repo.model_dump())
         repo_config['teams'] = {
@@ -419,7 +419,7 @@ class TestAssignment:
             git_repository,
             caching=True,
             data={'github': {'user': 'foo', 'token': 'bar'}, 'jira': {'email': 'foo@bar.baz', 'token': 'bar'}},
-            github_teams={'foo-team': ['github-foo1']},
+            github_teams={'foo-team': ['github-foo1'], 'bar-team': ['github-bar1']},
         )
         repo_config = dict(auto_mode_app.repo.model_dump())
         repo_config['teams'] = {
@@ -568,12 +568,120 @@ class TestAssignment:
             assert str(assignments[1].label.render()) == 'bar-team'
             assert assignments[1].switch.value
 
+    async def test_author_team_overrides_labels(self, app, git_repository, helpers, mock_pull_requests):
+        app.configure(
+            git_repository,
+            caching=True,
+            data={'github': {'user': 'foo', 'token': 'bar'}, 'jira': {'email': 'foo@bar.baz', 'token': 'bar'}},
+            github_teams={'foo-team': ['github-foo1'], 'bar-team': ['username1']},
+        )
+        repo_config = dict(app.repo.model_dump())
+        repo_config['teams'] = {
+            'foo': {
+                'jira_project': 'FOO',
+                'jira_issue_type': 'Foo-Task',
+                'jira_statuses': {'TODO': 'Backlog', 'IN PROGRESS': 'Sprint', 'DONE': 'Done'},
+                'github_team': 'foo-team',
+                'github_labels': ['foo-label'],
+            },
+            'bar': {
+                'jira_project': 'BAR',
+                'jira_issue_type': 'Bar-Task',
+                'jira_statuses': {'TODO': 'Backlog', 'IN PROGRESS': 'Sprint', 'DONE': 'Done'},
+                'github_team': 'bar-team',
+                'github_labels': ['bar-label'],
+            },
+        }
+        app.save_repo_config(repo_config)
+
+        # PR has foo-label AND bar-label but author (username1) is only in bar-team
+        mock_pull_requests(
+            {
+                'number': '1',
+                'title': 'title1',
+                'user': {'login': 'username1', 'html_url': 'https://github.com/username1'},
+                'labels': [{'name': 'foo-label', 'color': '632ca6'}, {'name': 'bar-label', 'color': '632ca6'}],
+                'body': 'foo1\r\nbar1',
+            },
+        )
+
+        async with app.run_test() as pilot:
+            await pilot.pause(helpers.ASYNC_WAIT)
+
+            sidebar = app.query_one(CandidateSidebar)
+            table = sidebar.listing
+            assert len(table.rows) == 1
+            assert table.get_row_at(0) == ['✓', 'title1']
+
+            rendering = app.query_one(CandidateRendering)
+            assignments = list(rendering.candidate_assignments.query(LabeledSwitch).results())
+            assert len(assignments) == 2
+            # Only bar is assigned (author's team), not foo (despite foo-label match)
+            assert str(assignments[0].label.render()) == 'foo'
+            assert not assignments[0].switch.value
+            assert str(assignments[1].label.render()) == 'bar'
+            assert assignments[1].switch.value
+
+    async def test_author_team_fallback_to_labels(self, app, git_repository, helpers, mock_pull_requests):
+        app.configure(
+            git_repository,
+            caching=True,
+            data={'github': {'user': 'foo', 'token': 'bar'}, 'jira': {'email': 'foo@bar.baz', 'token': 'bar'}},
+            github_teams={'foo-team': ['github-foo1'], 'bar-team': ['github-bar1']},
+        )
+        repo_config = dict(app.repo.model_dump())
+        repo_config['teams'] = {
+            'foo': {
+                'jira_project': 'FOO',
+                'jira_issue_type': 'Foo-Task',
+                'jira_statuses': {'TODO': 'Backlog', 'IN PROGRESS': 'Sprint', 'DONE': 'Done'},
+                'github_team': 'foo-team',
+                'github_labels': ['foo-label'],
+            },
+            'bar': {
+                'jira_project': 'BAR',
+                'jira_issue_type': 'Bar-Task',
+                'jira_statuses': {'TODO': 'Backlog', 'IN PROGRESS': 'Sprint', 'DONE': 'Done'},
+                'github_team': 'bar-team',
+                'github_labels': ['bar-label'],
+            },
+        }
+        app.save_repo_config(repo_config)
+
+        # PR author (unknown-user) is not in any team, should fall back to label matching
+        mock_pull_requests(
+            {
+                'number': '1',
+                'title': 'title1',
+                'user': {'login': 'unknown-user', 'html_url': 'https://github.com/unknown-user'},
+                'labels': [{'name': 'foo-label', 'color': '632ca6'}],
+                'body': 'foo1\r\nbar1',
+            },
+        )
+
+        async with app.run_test() as pilot:
+            await pilot.pause(helpers.ASYNC_WAIT)
+
+            sidebar = app.query_one(CandidateSidebar)
+            table = sidebar.listing
+            assert len(table.rows) == 1
+            assert table.get_row_at(0) == ['✓', 'title1']
+
+            rendering = app.query_one(CandidateRendering)
+            assignments = list(rendering.candidate_assignments.query(LabeledSwitch).results())
+            assert len(assignments) == 2
+            # Falls back to label matching: foo-label matches foo team
+            assert str(assignments[0].label.render()) == 'foo'
+            assert assignments[0].switch.value
+            assert str(assignments[1].label.render()) == 'bar'
+            assert not assignments[1].switch.value
+
     async def test_choice(self, app, git_repository, helpers, mock_pull_requests):
         app.configure(
             git_repository,
             caching=True,
             data={'github': {'user': 'foo', 'token': 'bar'}, 'jira': {'email': 'foo@bar.baz', 'token': 'bar'}},
-            github_teams={'foo-team': ['github-foo1']},
+            github_teams={'foo-team': ['github-foo1'], 'bar-team': ['github-bar1']},
         )
         repo_config = dict(app.repo.model_dump())
         repo_config['teams'] = {
@@ -695,7 +803,7 @@ class TestAssignment:
             git_repository,
             caching=True,
             data={'github': {'user': 'foo', 'token': 'bar'}, 'jira': {'email': 'foo@bar.baz', 'token': 'bar'}},
-            github_teams={'foo-team': ['github-foo1']},
+            github_teams={'foo-team': ['github-foo1'], 'bar-team': ['github-bar1']},
         )
         repo_config = dict(app.repo.model_dump())
         repo_config['ignored_labels'] = ['baz-label']
@@ -875,15 +983,6 @@ class TestCreation:
                     request=Request('POST', ''),
                     content=json.dumps(
                         {
-                            'key': 'FOO-2',
-                        },
-                    ),
-                ),
-                Response(
-                    200,
-                    request=Request('POST', ''),
-                    content=json.dumps(
-                        {
                             'key': 'BAR-2',
                         },
                     ),
@@ -992,30 +1091,7 @@ class TestCreation:
                         },
                     },
                 ),
-                mocker.call(
-                    'POST',
-                    'https://foobarbaz.atlassian.net/rest/api/2/issue',
-                    auth=('foo@bar.baz', 'bar'),
-                    json={
-                        'fields': {
-                            'assignee': {'id': foo_team_value.inverse()},
-                            'description': helpers.dedent(
-                                """
-                                Pull request: [#1|https://github.com/org/repo/pull/1]
-                                Author: [github-bar1|https://github.com/github-bar1]
-                                Labels: {{foo-label}}, {{bar-label}}
-
-                                foo1
-                                bar1
-                                """
-                            ),
-                            'issuetype': {'name': 'Foo-Task'},
-                            'labels': ['qa-1.2.3', 'label-9000'],
-                            'project': {'key': 'FOO'},
-                            'summary': 'title1',
-                        },
-                    },
-                ),
+                # PR #1 author (github-bar1) is in bar-team, so only Bar Baz is assigned
                 mocker.call(
                     'POST',
                     'https://foobarbaz.atlassian.net/rest/api/2/issue',

--- a/tests/screens/test_create.py
+++ b/tests/screens/test_create.py
@@ -1053,16 +1053,14 @@ class TestCreation:
                     json={
                         'fields': {
                             'assignee': {'id': foo_team_value},
-                            'description': helpers.dedent(
-                                """
+                            'description': helpers.dedent("""
                                 Pull request: [#2|https://github.com/org/repo/pull/2]
                                 Author: [github-foo1|https://github.com/github-foo1]
                                 Labels: {{foo-label}}
 
                                 foo2
                                 bar2
-                                """
-                            ),
+                                """),
                             'issuetype': {'name': 'Foo-Task'},
                             'labels': ['qa-1.2.3', 'label-9000'],
                             'project': {'key': 'FOO'},
@@ -1077,13 +1075,11 @@ class TestCreation:
                     json={
                         'fields': {
                             'assignee': {'id': bar_team_value},
-                            'description': helpers.dedent(
-                                """
+                            'description': helpers.dedent("""
                                 Commit: [hash3|https://github.com/org/repo/commit/hash3]
 
 
-                                """
-                            ),
+                                """),
                             'issuetype': {'name': 'Bar-Task'},
                             'labels': ['qa-1.2.3', 'label-9000'],
                             'project': {'key': 'BAR'},
@@ -1099,16 +1095,14 @@ class TestCreation:
                     json={
                         'fields': {
                             'assignee': {'id': bar_team_value.inverse()},
-                            'description': helpers.dedent(
-                                """
+                            'description': helpers.dedent("""
                                 Pull request: [#1|https://github.com/org/repo/pull/1]
                                 Author: [github-bar1|https://github.com/github-bar1]
                                 Labels: {{foo-label}}, {{bar-label}}
 
                                 foo1
                                 bar1
-                                """
-                            ),
+                                """),
                             'issuetype': {'name': 'Bar-Task'},
                             'labels': ['qa-1.2.3', 'label-9000'],
                             'project': {'key': 'BAR'},

--- a/tests/screens/test_sync.py
+++ b/tests/screens/test_sync.py
@@ -45,11 +45,9 @@ async def test_response_error(app, git_repository, helpers, mocker):
         assert '500' in str(status.render())
 
         text_log = sidebar.query_one(RichLog)
-        assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-            f"""
+        assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(f"""
             Fetching global config from: {app.repo.global_config_source}
-            """
-        )
+            """)
 
         button = sidebar.query_one(Button)
         assert button.disabled
@@ -70,11 +68,9 @@ async def test_parsing_error(app, git_repository, helpers, mocker):
         assert str(status.render()) == 'Unable to parse TOML source'
 
         text_log = sidebar.query_one(RichLog)
-        assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-            f"""
+        assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(f"""
             Fetching global config from: {app.repo.global_config_source}
-            """
-        )
+            """)
 
         button = sidebar.query_one(Button)
         assert button.disabled
@@ -103,11 +99,9 @@ async def test_no_members(application, auto_mode, request, git_repository, helpe
         assert str(status.render()) == 'No members found in TOML source'
 
         text_log = sidebar.query_one(RichLog)
-        assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-            f"""
+        assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(f"""
             Fetching global config from: {app.repo.global_config_source}
-            """
-        )
+            """)
 
         button = sidebar.query_one(Button)
         assert button.disabled
@@ -135,14 +129,12 @@ async def test_save_members(application, auto_mode, request, git_repository, hel
             Response(
                 200,
                 request=Request('GET', ''),
-                content=helpers.dedent(
-                    """
+                content=helpers.dedent("""
                     jira_server = "https://foo.atlassian.net"
 
                     [members]
                     g = "j"
-                    """
-                ),
+                    """),
             ),
             Response(500, request=Request('GET', '')),
         ],
@@ -170,12 +162,10 @@ async def test_save_members(application, auto_mode, request, git_repository, hel
         sidebar = app.query_one(InteractiveSidebar)
 
         text_log = sidebar.query_one(RichLog)
-        assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-            f"""
+        assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(f"""
             Fetching global config from: {app.repo.global_config_source}
             Refreshing members for team: bar-team
-            """
-        )
+            """)
 
         button = sidebar.query_one(Button)
         assert button.disabled
@@ -208,16 +198,14 @@ async def test_save_teams(application, auto_mode, git_repository, helpers, mocke
             Response(
                 200,
                 request=Request('GET', ''),
-                content=helpers.dedent(
-                    """
+                content=helpers.dedent("""
                     jira_server = "https://foo.atlassian.net"
 
                     [members]
                     g = "j"
                     foo1 = "jira-foo1"
                     bar1 = "jira-bar1"
-                    """
-                ),
+                    """),
             ),
         ],
     )
@@ -248,15 +236,13 @@ async def test_save_teams(application, auto_mode, git_repository, helpers, mocke
         assert not str(status.render())
 
         text_log = sidebar.query_one(RichLog)
-        assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-            f"""
+        assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(f"""
             Fetching global config from: {app.repo.global_config_source}
             Refreshing members for team: bar-team
             Refreshing members for team: foo-team
             Validating the github-metadata configuration...
             Validating 3 Jira users...
-            """
-        )
+            """)
 
         button = sidebar.query_one(Button)
         assert not button.disabled
@@ -289,16 +275,14 @@ async def test_deactivated_jira_user(application, auto_mode, git_repository, hel
             Response(
                 200,
                 request=Request('GET', ''),
-                content=helpers.dedent(
-                    """
+                content=helpers.dedent("""
                     jira_server = "https://foo.atlassian.net"
 
                     [members]
                     g = "j"
                     foo1 = "jira-foo1"
                     bar1 = "jira-bar1"
-                    """
-                ),
+                    """),
             ),
         ],
     )
@@ -328,16 +312,14 @@ async def test_deactivated_jira_user(application, auto_mode, git_repository, hel
         sidebar = app.query_one(InteractiveSidebar)
         text_log = sidebar.query_one(RichLog)
 
-        assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-            f"""
+        assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(f"""
             Fetching global config from: {app.repo.global_config_source}
             Refreshing members for team: bar-team
             Refreshing members for team: foo-team
             Validating the github-metadata configuration...
             Validating 3 Jira users...
             User g is deactivated on Jira
-            """
-        )
+            """)
 
         button = sidebar.query_one(Button)
         assert not button.disabled
@@ -371,15 +353,13 @@ async def test_github_user_not_in_jira(application, auto_mode, git_repository, h
             Response(
                 200,
                 request=Request('GET', ''),
-                content=helpers.dedent(
-                    """
+                content=helpers.dedent("""
                     jira_server = "https://foo.atlassian.net"
 
                     [members]
                     g = "j"
                     foo1 = "jira-foo1"
-                    """
-                ),
+                    """),
             ),
         ],
     )
@@ -407,16 +387,14 @@ async def test_github_user_not_in_jira(application, auto_mode, git_repository, h
     async with app.run_test():
         sidebar = app.query_one(InteractiveSidebar)
         text_log = sidebar.query_one(RichLog)
-        assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-            f"""
+        assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(f"""
             Fetching global config from: {app.repo.global_config_source}
             Refreshing members for team: bar-team
             Refreshing members for team: foo-team
             GitHub user bar1 is not declared in the Jira config
             Validating the github-metadata configuration...
             Validating 2 Jira users...
-            """
-        )
+            """)
 
         button = sidebar.query_one(Button)
         assert not button.disabled
@@ -449,8 +427,7 @@ async def test_duplicate_jira_user(application, auto_mode, git_repository, helpe
             Response(
                 200,
                 request=Request('GET', ''),
-                content=helpers.dedent(
-                    """
+                content=helpers.dedent("""
                     jira_server = "https://foo.atlassian.net"
 
                     [members]
@@ -458,8 +435,7 @@ async def test_duplicate_jira_user(application, auto_mode, git_repository, helpe
                     foo1 = "jira-foo1"
                     bar1 = "jira-foo1"
                     baz1 = "jira-baz1"
-                    """
-                ),
+                    """),
             ),
         ],
     )
@@ -489,16 +465,14 @@ async def test_duplicate_jira_user(application, auto_mode, git_repository, helpe
         sidebar = app.query_one(InteractiveSidebar)
         text_log = sidebar.query_one(RichLog)
 
-        assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(
-            f"""
+        assert '\n'.join(line.text for line in text_log.lines) == helpers.dedent(f"""
             Fetching global config from: {app.repo.global_config_source}
             Refreshing members for team: bar-team
             Refreshing members for team: foo-team
             Validating the github-metadata configuration...
             Jira user `jira-foo1` is declared multiple times in the Jira config with GitHub user `foo1`
             Jira user `jira-foo1` is declared multiple times in the Jira config with GitHub user `bar1`
-            """
-        )
+            """)
 
         button = sidebar.query_one(Button)
         assert button.disabled

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -9,6 +9,7 @@ import pytest
 from httpx import Request, Response
 from textual.widgets import Static
 
+from ddqa.models.config.team import TeamConfig
 from ddqa.models.github import PullRequestLabel
 from ddqa.models.github import TestCandidate as Candidate
 from ddqa.utils.git import GitCommit
@@ -1031,3 +1032,98 @@ async def test_rate_limit_handling(app, git_repository, mocker):
         ],
         'assigned_teams': set(),
     }
+
+
+class TestAuthorTeam:
+    @pytest.fixture
+    def teams(self):
+        return {
+            'foo': TeamConfig(
+                jira_project='FOO',
+                jira_issue_type='Task',
+                jira_statuses=['TODO'],
+                github_team='foo-team',
+                github_labels=['foo-label'],
+            ),
+            'bar': TeamConfig(
+                jira_project='BAR',
+                jira_issue_type='Task',
+                jira_statuses=['TODO'],
+                github_team='bar-team',
+                github_labels=['bar-label'],
+            ),
+        }
+
+    async def test_author_in_first_team(self, app, git_repository, mocker, teams):
+        app.configure(
+            git_repository,
+            caching=True,
+            data={'github': {'user': 'foo', 'token': 'bar'}, 'jira': {'email': 'foo@bar.baz', 'token': 'bar'}},
+        )
+
+        mocker.patch(
+            'httpx.AsyncClient.get',
+            return_value=Response(
+                200,
+                request=Request('GET', ''),
+                content=json.dumps([
+                    {'login': 'alice', 'type': 'User'},
+                    {'login': 'bob', 'type': 'User'},
+                ]),
+            ),
+        )
+
+        result = await app.github.get_author_team(ResponsiveNetworkClient(Static()), 'alice', teams)
+        assert result == 'foo'
+
+    async def test_author_in_second_team(self, app, git_repository, mocker, teams):
+        app.configure(
+            git_repository,
+            caching=True,
+            data={'github': {'user': 'foo', 'token': 'bar'}, 'jira': {'email': 'foo@bar.baz', 'token': 'bar'}},
+        )
+
+        mocker.patch(
+            'httpx.AsyncClient.get',
+            side_effect=[
+                Response(
+                    200,
+                    request=Request('GET', ''),
+                    content=json.dumps([{'login': 'alice', 'type': 'User'}]),
+                ),
+                Response(
+                    200,
+                    request=Request('GET', ''),
+                    content=json.dumps([{'login': 'charlie', 'type': 'User'}]),
+                ),
+            ],
+        )
+
+        result = await app.github.get_author_team(ResponsiveNetworkClient(Static()), 'charlie', teams)
+        assert result == 'bar'
+
+    async def test_author_not_in_any_team(self, app, git_repository, mocker, teams):
+        app.configure(
+            git_repository,
+            caching=True,
+            data={'github': {'user': 'foo', 'token': 'bar'}, 'jira': {'email': 'foo@bar.baz', 'token': 'bar'}},
+        )
+
+        mocker.patch(
+            'httpx.AsyncClient.get',
+            side_effect=[
+                Response(
+                    200,
+                    request=Request('GET', ''),
+                    content=json.dumps([{'login': 'alice', 'type': 'User'}]),
+                ),
+                Response(
+                    200,
+                    request=Request('GET', ''),
+                    content=json.dumps([{'login': 'bob', 'type': 'User'}]),
+                ),
+            ],
+        )
+
+        result = await app.github.get_author_team(ResponsiveNetworkClient(Static()), 'unknown-user', teams)
+        assert result is None

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -1066,10 +1066,12 @@ class TestAuthorTeam:
             return_value=Response(
                 200,
                 request=Request('GET', ''),
-                content=json.dumps([
-                    {'login': 'alice', 'type': 'User'},
-                    {'login': 'bob', 'type': 'User'},
-                ]),
+                content=json.dumps(
+                    [
+                        {'login': 'alice', 'type': 'User'},
+                        {'login': 'bob', 'type': 'User'},
+                    ]
+                ),
             ),
         )
 

--- a/tests/utils/test_jira.py
+++ b/tests/utils/test_jira.py
@@ -182,8 +182,7 @@ async def test_create_issues(app, git_repository, helpers, mocker):
                 'fields': {
                     'assignee': {'id': 'jira-foo'},
                     'components': [{'name': 'Foo-Component'}],
-                    'description': helpers.dedent(
-                        """
+                    'description': helpers.dedent("""
                         Pull request: [#123|https://github.com/org/repo/pull/123]
                         Author: [user9000|https://github.com/user9000]
                         Labels: {{label1}}, {{label2}}
@@ -199,8 +198,7 @@ async def test_create_issues(app, git_repository, helpers, mocker):
                         {code}
 
                         [test link|https://example.com]
-                        """
-                    ),
+                        """),
                     'issuetype': {'name': 'Foo-Task'},
                     'labels': ['qa-1.2.3', 'label-9000'],
                     'project': {'key': 'FOO'},
@@ -216,8 +214,7 @@ async def test_create_issues(app, git_repository, helpers, mocker):
                 'fields': {
                     'assignee': {'id': 'jira-bar'},
                     'components': [{'name': 'Bar-Component'}],
-                    'description': helpers.dedent(
-                        """
+                    'description': helpers.dedent("""
                         Pull request: [#123|https://github.com/org/repo/pull/123]
                         Author: [user9000|https://github.com/user9000]
                         Labels: {{label1}}, {{label2}}
@@ -233,8 +230,7 @@ async def test_create_issues(app, git_repository, helpers, mocker):
                         {code}
 
                         [test link|https://example.com]
-                        """
-                    ),
+                        """),
                     'issuetype': {'name': 'Bar-Task'},
                     'labels': ['qa-1.2.3', 'label-9000'],
                     'project': {'key': 'BAR'},


### PR DESCRIPTION
## What does this PR do?

Changes QA card creation to assign a PR to the **author's GitHub team** rather than to every team whose labels match the PR. This is done by resolving the PR author's team membership via the existing `get_team_members()` API (which is already cached) during candidate loading.

### Key changes:
- **`GitHubRepository.get_author_team()`** — new method that iterates configured teams and returns the first one the author belongs to
- **`CandidateListing.__on_mount__()`** — resolves the author's team before creating `Candidate` objects, setting `assigned_teams` on the model
- **`Candidate.__init__()`** — when `assigned_teams` is set, it's now the sole source of truth (no fallthrough to label matching for other teams)

### Behavior:
| Scenario | Result |
|----------|--------|
| Author is in one configured team | Assigned to that team only |
| Author not in any configured team | Falls back to label matching |
| Non-PR commit (no author) | Falls back to label matching |
| Candidate has cached `assigned_teams` | Cache takes precedence |

## Motivation

Previously, a PR with multiple `team/*` labels would generate a Jira QA card for **every** matching team. The desired behavior is a single card for the author's own team, reducing noise and ensuring the right team owns the QA.

## How were changes validated?

- Added 3 unit tests for `get_author_team()` (author in first team, second team, not in any team)
- Added 2 screen tests: `test_author_team_overrides_labels` and `test_author_team_fallback_to_labels`
- Updated existing tests (`test_default`, `test_auto_mode`, `test_choice`, `test_ignored_labels`, `TestCreation::test_assignment`) to pre-cache all teams and reflect the new assignment behavior
- Full test suite passes (163 tests)