### PR TITLE
fix(publish): Grant permissions to the job

### DIFF
--- a/.github/dependabot.yml.disabled
+++ b/.github/dependabot.yml.disabled
@@ -1,6 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: "weekly"

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -19,6 +19,8 @@ jobs:
   publish:
     name: Publish documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs:
     - docs
 


### PR DESCRIPTION
Grant write permissions to the publish job to prevent current [failures](https://github.com/DataDog/ddqa/actions/workflows/publish-docs.yml)