### PR TITLE
[ACIX-1926] chore(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/build-macos-package/action.yml
+++ b/.github/actions/build-macos-package/action.yml
@@ -35,7 +35,7 @@ runs:
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v.6.0.0
+      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:
         python-version: ${{ inputs.python-version }}
         cache: pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
           tar --strip-components=1 -xzf - -C $PYAPP_REPO
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548  # v.6.1.0
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -210,7 +210,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548  # v.6.1.0
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 


### PR DESCRIPTION
Mechanical rewrite of every `uses:` reference to a full-length commit SHA, produced by [pinact](https://github.com/suzuki-shunsuke/pinact). An unpinned reference resolves to a mutable ref, so a compromise of the upstream action becomes code execution in this repository's CI.

The trailing `# vX.Y.Z` comment is what lets Renovate and Dependabot keep these bumped, so please keep it.

**One thing to check:** references that tracked `@main` or `@master` were resolved to the latest stable tag. If any of them floated deliberately and that behaviour was load-bearing here, say so on the PR and we will revert that line.
